### PR TITLE
Configuration enhancements

### DIFF
--- a/Source/Configuration.swift
+++ b/Source/Configuration.swift
@@ -13,10 +13,15 @@
 */
 public struct Configuration
     {
+    // MARK: General Resource Behavior
+
     /**
       Time before valid data is considered stale by `Resource.loadIfNeeded()`.
 
       The default is 30 seconds.
+
+      - Note: This property is configured at the resource level, and does not depend on the HTTP method of any request.
+        Siesta uses the value configured for GET; if you override this for other HTTP methods, Siesta will ignore it.
     */
     public var expirationTime: NSTimeInterval = 30
 
@@ -24,11 +29,29 @@ public struct Configuration
       Time `Resource.loadIfNeeded()` will wait before allowing a retry after a failed request.
 
       The default is 1 second.
+
+      - Note: This property is configured at the resource level, and does not depend on the HTTP method of any request.
+        Siesta uses the value configured for GET; if you override this for other HTTP methods, Siesta will ignore it.
     */
     public var retryTime: NSTimeInterval = 1
 
     /**
+      An optional store to maintain the state of resources between app launches.
+
+      - Note: This property is configured at the resource level, and does not depend on the HTTP method of any request.
+        Siesta uses the value configured for GET; if you override this for other HTTP methods, Siesta will ignore it.
+    */
+    public var persistentCache: EntityCache? = nil
+
+    // MARK: Request Handling
+
+    /**
       Default request headers.
+
+      - Note: `Resource.request(...)` accepts a `requestMutation` closure than can change the HTTP method of a request.
+        If you override configuration based on HTTP method, then unlike other configuration properties, `headers`
+        depends on the initially requested, _pre-mutation_ method of a request. All other configuration properties
+        will depend on the _post-mutation_ request method.
     */
     public var headers: [String:String] = [:]
 
@@ -59,16 +82,13 @@ public struct Configuration
     public var responseTransformers: TransformerSequence = TransformerSequence()
 
     /**
-      An optional store to maintain the state of resources between app launches.
-    */
-    public var persistentCache: EntityCache? = nil
-
-    /**
       Interval at which request hooks & observers receive progress updates. This affects how frequently
       `Request.onProgress(_:)` and `ResourceObserver.resourceRequestProgress(_:progress:)` are called, and how often the
       `Request.progress` property (which is partially time-based) is updated.
     */
     public var progressReportingInterval: NSTimeInterval = 0.05
+
+    // MARK: Creating Configurations
 
     /**
       Holds a mutable configuration while closures passed to `Service.configure(...)` modify it.

--- a/Source/Request/NetworkRequest.swift
+++ b/Source/Request/NetworkRequest.swift
@@ -10,6 +10,7 @@ internal final class NetworkRequest: RequestWithDefaultCallbacks, CustomDebugStr
     {
     // Basic metadata
     private let resource: Resource
+    private let requestMethod: RequestMethod
     private let requestDescription: String
 
     // Networking
@@ -38,6 +39,7 @@ internal final class NetworkRequest: RequestWithDefaultCallbacks, CustomDebugStr
         self.resource = resource
         self.nsreq = nsreq
         self.requestDescription = debugStr([nsreq.HTTPMethod, nsreq.URL])
+        self.requestMethod = RequestMethod(rawValue: nsreq.HTTPMethod ?? "") ?? .GET
 
         progressTracker = ProgressTracker(isGet: nsreq.HTTPMethod == "GET")
         }
@@ -68,7 +70,7 @@ internal final class NetworkRequest: RequestWithDefaultCallbacks, CustomDebugStr
 
         progressTracker.start(
             networking,
-            reportingInterval: resource.config.progressReportingInterval)
+            reportingInterval: resource.config(forRequestMethod: requestMethod).progressReportingInterval)
 
         return self
         }
@@ -161,7 +163,7 @@ internal final class NetworkRequest: RequestWithDefaultCallbacks, CustomDebugStr
 
     private func transformResponse(rawInfo: ResponseInfo, then afterTransformation: ResponseInfo -> Void)
         {
-        let transformer = resource.config.responseTransformers
+        let transformer = resource.config(forRequestMethod: requestMethod).responseTransformers
         dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0))
             {
             let processedInfo =

--- a/Source/Request/NetworkRequest.swift
+++ b/Source/Request/NetworkRequest.swift
@@ -10,8 +10,9 @@ internal final class NetworkRequest: RequestWithDefaultCallbacks, CustomDebugStr
     {
     // Basic metadata
     private let resource: Resource
-    private let requestMethod: RequestMethod
     private let requestDescription: String
+    internal var config: Configuration
+        { return resource.config(forRequest: nsreq) }
 
     // Networking
     private let nsreq: NSURLRequest
@@ -39,7 +40,6 @@ internal final class NetworkRequest: RequestWithDefaultCallbacks, CustomDebugStr
         self.resource = resource
         self.nsreq = nsreq
         self.requestDescription = debugStr([nsreq.HTTPMethod, nsreq.URL])
-        self.requestMethod = RequestMethod(rawValue: nsreq.HTTPMethod ?? "") ?? .GET
 
         progressTracker = ProgressTracker(isGet: nsreq.HTTPMethod == "GET")
         }
@@ -70,7 +70,7 @@ internal final class NetworkRequest: RequestWithDefaultCallbacks, CustomDebugStr
 
         progressTracker.start(
             networking,
-            reportingInterval: resource.config(forRequestMethod: requestMethod).progressReportingInterval)
+            reportingInterval: config.progressReportingInterval)
 
         return self
         }
@@ -163,7 +163,7 @@ internal final class NetworkRequest: RequestWithDefaultCallbacks, CustomDebugStr
 
     private func transformResponse(rawInfo: ResponseInfo, then afterTransformation: ResponseInfo -> Void)
         {
-        let transformer = resource.config(forRequestMethod: requestMethod).responseTransformers
+        let transformer = config.responseTransformers
         dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0))
             {
             let processedInfo =

--- a/Source/Request/Request.swift
+++ b/Source/Request/Request.swift
@@ -31,6 +31,8 @@ public enum RequestMethod: String
     ///
     /// I’m here all week! Thank you for reading the documentation!
     case DELETE
+
+    internal static let all: Set<RequestMethod> = [.GET, .POST, .PUT, .PATCH, .DELETE]
     }
 
 /**

--- a/Source/Request/Request.swift
+++ b/Source/Request/Request.swift
@@ -32,7 +32,7 @@ public enum RequestMethod: String
     /// I’m here all week! Thank you for reading the documentation!
     case DELETE
 
-    internal static let all: Set<RequestMethod> = [.GET, .POST, .PUT, .PATCH, .DELETE]
+    internal static let all: [RequestMethod] = [.GET, .POST, .PUT, .PATCH, .DELETE]
     }
 
 /**

--- a/Source/Resource.swift
+++ b/Source/Resource.swift
@@ -36,35 +36,25 @@ public final class Resource: NSObject
 
     internal var observers = [ObserverEntry]()
 
-    // MARK: Configuration
-
-    /**
-      Configuration options for this resource.
-
-      Note that this is a read-only computed property. You cannot directly change an individual resource's configuration.
-      The reason for this is that resource instances are created on demand, and can disappear under memory pressure when
-      not in use. Any configuration applied a particular resource instance would therefore be transient.
-
-      Instead, you must use the `Service.configure(...)` methods. This sets up configuration to be applied to resources
-      according to their URL, whenever they are created or recreated.
-
-      - Complexity:
-        - O(*n*) on first call after creation, or after invalidation (via `Service.invalidateConfiguration()`),
-          where _n_ is the number of past calls to `Service.configure(...)` for this resource’s `Service`.
-        - O(1) on subsequent invocations.
-    */
-    public var config: Configuration
+    internal func config(forRequestMethod method: RequestMethod) -> Configuration
         {
         dispatch_assert_main_queue()
 
         if configVersion != service.configVersion
             {
-            cachedConfig = service.configurationForResource(self)
+            cachedConfig.removeAll()
             configVersion = service.configVersion
             }
-        return cachedConfig
+
+        return cachedConfig.cacheValue(forKey: method)
+            { service.configuration(forResource: self, requestMethod: method) }
         }
-    private var cachedConfig: Configuration = Configuration()
+
+    /// Configuration when there is no request method.
+    internal var generalConfig: Configuration
+        { return config(forRequestMethod: .GET) }
+
+    private var cachedConfig: [RequestMethod:Configuration] = [:]
     private var configVersion: UInt64 = 0
 
 
@@ -295,7 +285,7 @@ public final class Resource: NSObject
 
         let nsreq = NSMutableURLRequest(URL: url)
         nsreq.HTTPMethod = method.rawValue
-        for (header,value) in config.headers
+        for (header,value) in config(forRequestMethod: method).headers
             { nsreq.setValue(value, forHTTPHeaderField: header) }
 
         requestMutation(nsreq)
@@ -304,7 +294,7 @@ public final class Resource: NSObject
 
         let req = NetworkRequest(resource: self, nsreq: nsreq)
         trackRequest(req, using: &allRequests)
-        for callback in config.beforeStartingRequestCallbacks
+        for callback in config(forRequestMethod: method).beforeStartingRequestCallbacks
             { callback(self, req) }
 
         return req.start()
@@ -327,8 +317,8 @@ public final class Resource: NSObject
     public var isUpToDate: Bool
         {
         let maxAge = (latestError == nil)
-                ? config.expirationTime
-                : config.retryTime,
+                ? generalConfig.expirationTime
+                : generalConfig.retryTime,
             currentTime = now(),
             result = !invalidated && currentTime - timestamp <= maxAge
 
@@ -359,9 +349,9 @@ public final class Resource: NSObject
 
         debugLog(.Staleness,
             [self, (result ? "is" : "is not"), "up to date:"]
-            + formatExpirationTime("error", latestError?.timestamp, config.retryTime)
+            + formatExpirationTime("error", latestError?.timestamp, generalConfig.retryTime)
             + ["|"]
-            + formatExpirationTime("data",  latestData?.timestamp,  config.expirationTime))
+            + formatExpirationTime("data",  latestData?.timestamp,  generalConfig.expirationTime))
         }
 
     /**
@@ -651,7 +641,7 @@ public final class Resource: NSObject
 
     private func initializeDataFromCache()
         {
-        guard let cache = config.persistentCache else
+        guard let cache = generalConfig.persistentCache else
             { return }
 
         let url = self.url
@@ -677,7 +667,7 @@ public final class Resource: NSObject
 
     private func writeDataToCache()
         {
-        if let cache = config.persistentCache, let entity = latestData
+        if let cache = generalConfig.persistentCache, let entity = latestData
             {
             let url = self.url
             debugLog(.Cache, ["Caching data for", url, "in", cache])

--- a/Source/Resource.swift
+++ b/Source/Resource.swift
@@ -50,6 +50,13 @@ public final class Resource: NSObject
             { service.configuration(forResource: self, requestMethod: method) }
         }
 
+    internal func config(forRequest request: NSURLRequest) -> Configuration
+        {
+        return config(forRequestMethod:
+            RequestMethod(rawValue: request.HTTPMethod?.uppercaseString ?? "")
+                ?? .GET)  // All unrecognized methods default to .GET
+        }
+
     /// Configuration when there is no request method.
     internal var generalConfig: Configuration
         { return config(forRequestMethod: .GET) }
@@ -294,7 +301,7 @@ public final class Resource: NSObject
 
         let req = NetworkRequest(resource: self, nsreq: nsreq)
         trackRequest(req, using: &allRequests)
-        for callback in config(forRequestMethod: method).beforeStartingRequestCallbacks
+        for callback in req.config.beforeStartingRequestCallbacks
             { callback(self, req) }
 
         return req.start()

--- a/Source/Service.swift
+++ b/Source/Service.swift
@@ -189,7 +189,7 @@ public class Service: NSObject
     */
     public final func configure(
             pattern: ConfigurationPatternConvertible,
-            requestMethods: Set<RequestMethod>? = nil,
+            requestMethods: [RequestMethod]? = nil,
             description: String? = nil,
             configurer: Configuration.Builder -> Void)
         {
@@ -214,7 +214,7 @@ public class Service: NSObject
     */
     public final func configure(
             whenURLMatches configurationPattern: NSURL -> Bool = { _ in true },
-            requestMethods: Set<RequestMethod>? = nil,
+            requestMethods: [RequestMethod]? = nil,
             description: String? = nil,
             configurer: Configuration.Builder -> Void)
         {
@@ -222,7 +222,7 @@ public class Service: NSObject
 
         let entry = ConfigurationEntry(
             description: "config \(nextConfigID) [" + (description ?? "custom") + "]",
-            requestMethods: requestMethods ?? RequestMethod.all,
+            requestMethods: Set(requestMethods ?? RequestMethod.all),
             configurationPattern: configurationPattern,
             configurer: configurer)
         configurationEntries.append(entry)
@@ -254,7 +254,7 @@ public class Service: NSObject
     */
     public final func configureTransformer<I,O>(
             pattern: ConfigurationPatternConvertible,
-            requestMethods: Set<RequestMethod>? = nil,
+            requestMethods: [RequestMethod]? = nil,
             description: String? = nil,
             contentTransform: ResponseContentTransformer<I,O>.Processor)
         {

--- a/Source/Service.swift
+++ b/Source/Service.swift
@@ -180,7 +180,8 @@ public class Service: NSObject
           sees fit. This closure will be called whenever Siesta needs to generate or refresh configuration. You should
           not rely on it being called at any particular time, and should avoid making it cause side effects.
 
-      - SeeAlso: `configure(whenURLMatches:description:configurer:)` for global config and more fine-grained matching
+      - SeeAlso: `configure(whenURLMatches:requestMethods:description:configurer:)`
+          for global config and more fine-grained matching
       - SeeAlso: `invalidateConfiguration()`
       - SeeAlso: For more details about the rules of pattern matching:
         - `String.configurationPattern(_:)`
@@ -209,7 +210,8 @@ public class Service: NSObject
       - Parameter whenURLMatches:
           A predicate that matches absolute URLs of resources. The default is a predicate that matches anything.
 
-      - SeeAlso: `configure(_:description:configurer:)` for pattern-based matching, and for details about the parameters.
+      - SeeAlso: `configure(_:requestMethods:description:configurer:)`
+          for pattern-based matching, and for details about the parameters.
       - SeeAlso: `invalidateConfiguration()`
     */
     public final func configure(
@@ -250,7 +252,10 @@ public class Service: NSObject
             $0.content as NSJSONConvertible
           }
 
-      - SeeAlso: ResponseContentTransformer
+      - SeeAlso: `configure(_:requestMethods:description:configurer:)`
+          for more into about the parameters and configuration pattern matching.
+      - SeeAlso: `ResponseContentTransformer`
+          for more robust transformation options.
     */
     public final func configureTransformer<I,O>(
             pattern: ConfigurationPatternConvertible,

--- a/Source/Support/Collection+Siesta.swift
+++ b/Source/Support/Collection+Siesta.swift
@@ -94,6 +94,18 @@ internal extension Dictionary
                 }
             )
         }
+
+    @warn_unused_result
+    mutating func cacheValue(forKey key: Key, @noescape ifNone newValue: () -> Value)
+        -> Value
+        {
+        return self[key] ??
+            {
+            let newValue = newValue()
+            self[key] = newValue
+            return newValue
+            }()
+        }
     }
 
 internal extension Set

--- a/Source/Support/Deprecations.swift
+++ b/Source/Support/Deprecations.swift
@@ -6,6 +6,17 @@
 //  Copyright © 2016 Bust Out Solutions. All rights reserved.
 //
 
+// MARK: - Deprecated in beta 7
+
+extension Resource
+    {
+    @available(*, deprecated=0.99, message="This property is going away from the public API. If you have a need for it, please file a Github issue describing your use case.")
+    public var config: Configuration
+        { return generalConfig }
+    }
+
+// MARK: - Deprecated in beta 6
+
 extension Entity
     {
     @available(*, deprecated=0.99, renamed="Entity(response:content:)")

--- a/Tests/ResourceRequestsSpec.swift
+++ b/Tests/ResourceRequestsSpec.swift
@@ -564,7 +564,6 @@ class ResourceRequestsSpec: ResourceSpecBase
                 it("respects custom expiration time")
                     {
                     service().configure("**") { $0.config.expirationTime = 1 }
-                    expect(resource().config.expirationTime) == 1
                     setResourceTime(1002)
                     expectToLoad(resource().loadIfNeeded())
                     }

--- a/Tests/ServiceSpec.swift
+++ b/Tests/ServiceSpec.swift
@@ -189,6 +189,15 @@ class ServiceSpec: SiestaSpec
                 expect(resource1().generalConfig.expirationTime) == 30
                 }
 
+            it("applies request config only to matching request methods")
+                {
+                service().configure(requestMethods: [.POST])
+                    { $0.config.expirationTime = 19 }
+                expect(resource0().generalConfig.expirationTime) == 30
+                expect(resource0().config(forRequestMethod: .PUT).expirationTime) == 30
+                expect(resource0().config(forRequestMethod: .POST).expirationTime) == 19
+                }
+
             func checkPattern(
                     pattern: ConfigurationPatternConvertible,
                     matches: Bool,

--- a/Tests/ServiceSpec.swift
+++ b/Tests/ServiceSpec.swift
@@ -160,6 +160,13 @@ class ServiceSpec: SiestaSpec
                 expect(resource1().config.expirationTime) == 17
                 }
 
+            it("allows config blocks to be named for logging purposes")
+                {
+                service().configure(description: "global config")
+                    { $0.config.expirationTime = 17 }
+                expect(resource0().config.expirationTime) == 17
+                }
+
             it("passes default configuration through if not overridden")
                 {
                 service().configure { $0.config.retryTime = 17 }
@@ -176,7 +183,7 @@ class ServiceSpec: SiestaSpec
 
             it("applies predicate config only to matching resources")
                 {
-                service().configure({ $0.absoluteString.hasSuffix("foo") })
+                service().configure(whenURLMatches: { $0.absoluteString.hasSuffix("foo") })
                     { $0.config.expirationTime = 17 }
                 expect(resource0().config.expirationTime) == 17
                 expect(resource1().config.expirationTime) == 30

--- a/Tests/ServiceSpec.swift
+++ b/Tests/ServiceSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2016 Bust Out Solutions. All rights reserved.
 //
 
-import Siesta
+@testable import Siesta
 import Quick
 import Nimble
 
@@ -156,37 +156,37 @@ class ServiceSpec: SiestaSpec
             it("applies global config to all resources")
                 {
                 service().configure { $0.config.expirationTime = 17 }
-                expect(resource0().config.expirationTime) == 17
-                expect(resource1().config.expirationTime) == 17
+                expect(resource0().generalConfig.expirationTime) == 17
+                expect(resource1().generalConfig.expirationTime) == 17
                 }
 
             it("allows config blocks to be named for logging purposes")
                 {
                 service().configure(description: "global config")
                     { $0.config.expirationTime = 17 }
-                expect(resource0().config.expirationTime) == 17
+                expect(resource0().generalConfig.expirationTime) == 17
                 }
 
             it("passes default configuration through if not overridden")
                 {
                 service().configure { $0.config.retryTime = 17 }
-                expect(resource0().config.expirationTime) == 30
+                expect(resource0().generalConfig.expirationTime) == 30
                 }
 
             it("applies resource-specific config only to that resource")
                 {
                 service().configure(resource0())
                     { $0.config.expirationTime = 17 }
-                expect(resource0().config.expirationTime) == 17
-                expect(resource1().config.expirationTime) == 30
+                expect(resource0().generalConfig.expirationTime) == 17
+                expect(resource1().generalConfig.expirationTime) == 30
                 }
 
             it("applies predicate config only to matching resources")
                 {
                 service().configure(whenURLMatches: { $0.absoluteString.hasSuffix("foo") })
                     { $0.config.expirationTime = 17 }
-                expect(resource0().config.expirationTime) == 17
-                expect(resource1().config.expirationTime) == 30
+                expect(resource0().generalConfig.expirationTime) == 17
+                expect(resource1().generalConfig.expirationTime) == 30
                 }
 
             func checkPattern(
@@ -205,7 +205,7 @@ class ServiceSpec: SiestaSpec
                 for (k,v) in params
                     { resource = resource.withParam(k, v) }
 
-                let actual = resource.config.expirationTime,
+                let actual = resource.generalConfig.expirationTime,
                     expected = matches ? 6.0 : 30.0,
                     matchword = matches ? "to" : "not to"
                 XCTAssert(expected == actual, "Expected \(pattern) \(matchword) match \(pathOrURL)")
@@ -327,22 +327,22 @@ class ServiceSpec: SiestaSpec
 
             it("changes when service config added")
                 {
-                expect(resource0().config.expirationTime) == 30
+                expect(resource0().generalConfig.expirationTime) == 30
                 service().configure { $0.config.expirationTime = 17 }
-                expect(resource0().config.expirationTime) == 17
+                expect(resource0().generalConfig.expirationTime) == 17
                 service().configure("*oo") { $0.config.expirationTime = 16 }
-                expect(resource0().config.expirationTime) == 16
+                expect(resource0().generalConfig.expirationTime) == 16
                 }
 
             it("changes when invalidateConfiguration() called")
                 {
                 var x: NSTimeInterval = 3
                 service().configure { $0.config.expirationTime = x }
-                expect(resource0().config.expirationTime) == 3
+                expect(resource0().generalConfig.expirationTime) == 3
                 x = 4
-                expect(resource0().config.expirationTime) == 3
+                expect(resource0().generalConfig.expirationTime) == 3
                 service().invalidateConfiguration()
-                expect(resource0().config.expirationTime) == 4
+                expect(resource0().generalConfig.expirationTime) == 4
                 }
             }
 


### PR DESCRIPTION
This adds the ability to specify configuration based on HTTP request method, which resolves #43:

    MyAPI.configureTransformer("/item", requestMethods: [.GET]) {
        Item(json: $0.content)
    }

    MyAPI.configureTransformer("/item", requestMethods: [.PUT, .POST]) {
        ItemUpdateResult(json: $0.content)
    }

Things to note about the implementation:

- Both `Service.configureTransformer(…)` and the various flavors of `Service.configure(…)` now accept a `requestMethods:` parameter.
- Some configuration properties (e.g. `expirationTime`) are used outside the context of a request, and thus cannot depend on the HTTP request method. Siesta will ignore any per-method overrides of such properties.
- A request mutation closure can modify the `NSMutableURLRequest` after Siesta creates it, and can thus change the HTTP method. After this mutation runs, Siesta always uses the post-mutation HTTP method for choosing configuration for a request. However, the default request headers are the one thing that get set _before_ the mutating closure (and must, since modifying them is one of the primary jobs of the mutator!). This means that it is possible, for example, for a request to use the default headers configured for a GET but the response transformers configured for a PUT.
- `Resource.config` is no longer a part of the public API, making resource configuration essentially write-only. It’s unclear to me why anyone really needed to inspect configuration after it was set, but if I learn of a compelling reason to make this public again, I will.

@majorgilles, I’d appreciate your feedback on whether this works for you before I merge.