### PR TITLE
? in glob syntax

### DIFF
--- a/Source/ConfigurationPatternConvertible.swift
+++ b/Source/ConfigurationPatternConvertible.swift
@@ -70,6 +70,7 @@ extension String: ConfigurationPatternConvertible
                 .replacingString("\\*\\*\\/", "([^:?]*/|)")
                 .replacingString("\\*\\*",    "[^:?]*")
                 .replacingString("\\*",       "[^/:?]*")
+                .replacingString("\\?",       "[^/:?]")
             + "($|\\?)")
         debugLog(.Configuration, ["URL pattern", self, "compiles to regex", pattern.pattern])
 

--- a/Source/ConfigurationPatternConvertible.swift
+++ b/Source/ConfigurationPatternConvertible.swift
@@ -39,16 +39,19 @@ extension String: ConfigurationPatternConvertible
       The `urlPattern` is interpreted relative to the service’s base URL unless it begins with a protocol (e.g. `http:`).
       If it is relative, the leading slash is optional.
 
-      The pattern supports two wildcards:
+      The pattern supports three wildcards:
 
-      - `*` matches zero or more characters within a path segment, and
+      - `*` matches zero or more characters within a path segment.
       - `**` matches zero or more characters across path segments, with the special case that `/**/` matches `/`.
+      - `?` matches exactly one character within a path segment, and thus `?*` matches one or more.
 
       Examples:
 
-      - `/foo/*/bar` matches `/foo/1/bar` and  `/foo/123/bar`.
+      - `/foo/*/bar` matches `/foo/1/bar` and `/foo/123/bar`.
       - `/foo/**/bar` matches `/foo/bar`, `/foo/123/bar`, and `/foo/1/2/3/bar`.
       - `/foo*/bar` matches `/foo/bar` and `/food/bar`.
+      - `/foo/​*` matches `/foo/123` and `/foo/`.
+      - `/foo/?*` matches `/foo/123` but _not_ `/foo/`.
 
       The pattern ignores the resource’s query string.
     */

--- a/Source/Resource.swift
+++ b/Source/Resource.swift
@@ -439,8 +439,7 @@ public final class Resource: NSObject
 
         trackRequest(req, using: &loadRequests)
 
-        req.onProgress
-            { self.notifyObservers(progress: $0) }
+        req.onProgress(notifyObservers)
 
         req.onNewData(receiveNewDataFromNetwork)
         req.onNotModified(receiveDataNotModified)

--- a/Source/ResourceObserver.swift
+++ b/Source/ResourceObserver.swift
@@ -312,7 +312,7 @@ internal struct ObserverEntry: CustomStringConvertible
     mutating func cleanUp()
         {
         // Look for weak refs which refer to objects that are now gone
-        externalOwners = Set(externalOwners.filter { $0.value != nil })  // TODO: improve performance (Can Swift modify Set in place while iterating?)
+        externalOwners.filterInPlace { $0.value != nil }
 
         observerRef.strong = !externalOwners.isEmpty
         }

--- a/Source/Support/Collection+Siesta.swift
+++ b/Source/Support/Collection+Siesta.swift
@@ -26,10 +26,7 @@ internal extension CollectionType
 
         return (included: included, excluded: excluded)
         }
-    }
 
-internal extension Array
-    {
     @warn_unused_result
     func any(@noescape predicate: Generator.Element -> Bool) -> Bool
         {
@@ -44,7 +41,10 @@ internal extension Array
         {
         return !any { !predicate($0) }
         }
+    }
 
+internal extension Array
+    {
     mutating func remove(@noescape predicate: Generator.Element -> Bool)
         {
         var dst = startIndex
@@ -93,5 +93,19 @@ internal extension Dictionary
                     { return nil }
                 }
             )
+        }
+    }
+
+internal extension Set
+    {
+    mutating func filterInPlace(@noescape predicate: Generator.Element -> Bool)
+        {
+        if !all(predicate)
+            {
+            // There's apparently no more performant way of doing this filter in place than creating a whole new set.
+            // Even the stdlib’s internal implementation does this for its similar mutating union/intersection methods.
+
+            self = Set(filter(predicate))
+            }
         }
     }

--- a/Tests/ServiceSpec.swift
+++ b/Tests/ServiceSpec.swift
@@ -259,6 +259,19 @@ class ServiceSpec: SiestaSpec
                     checkPattern("/**/*",   matches: true,  "/ab")
                     }
 
+                it("matches single non-separator chars with ?")
+                    {
+                    checkPattern("/?",      matches: false, "/")
+                    checkPattern("/?",      matches: true,  "/o")
+                    checkPattern("/??",     matches: false, "/o")
+                    checkPattern("/??",     matches: true,  "/oy")
+                    checkPattern("/??",     matches: false, "/oye")
+                    checkPattern("/??",     matches: false, "/o/")
+                    checkPattern("/x/?*",   matches: false, "/x/")
+                    checkPattern("/x/?*",   matches: true,  "/x/o")
+                    checkPattern("/x/?*",   matches: true,  "/x/oye")
+                    }
+
                 it("ignores query strings in the matched URL")
                     {
                     checkPattern("/*/b",  matches: true, "/a/b", params: ["foo": "bar"])


### PR DESCRIPTION
Based on discussion in #47, this PR adds support for a `?` wildcard to match exactly one character in a URL. This gives you the ability to distinguish a slash from a slash followed by more chars:

- `/foo/​*` matches `/foo/123` and `/foo/`.
- `/foo/?*` matches `/foo/123` but _not_ `/foo/`.

@enricode, I’d appreciate your feedback on whether this solves your issue before I merge this.