### PR TITLE
Use CocoaPods in example project

### DIFF
--- a/Examples/GithubBrowser/.gitignore
+++ b/Examples/GithubBrowser/.gitignore
@@ -1,1 +1,1 @@
-Carthage
+Pods

--- a/Examples/GithubBrowser/Cartfile
+++ b/Examples/GithubBrowser/Cartfile
@@ -1,2 +1,0 @@
-github "bustoutsolutions/siesta" "1.0-beta.6"
-github "SwiftyJSON/SwiftyJSON"

--- a/Examples/GithubBrowser/Cartfile.resolved
+++ b/Examples/GithubBrowser/Cartfile.resolved
@@ -1,2 +1,0 @@
-github "SwiftyJSON/SwiftyJSON" "2.3.3"
-github "bustoutsolutions/siesta" "1.0-beta.6"

--- a/Examples/GithubBrowser/GithubBrowser.xcodeproj/project.pbxproj
+++ b/Examples/GithubBrowser/GithubBrowser.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		713AB3CBE73243473E91C834 /* Pods_GithubBrowser.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 18CDC2D94A6B11796E5F8136 /* Pods_GithubBrowser.framework */; };
 		DA2B55621C7D6F8700EB4D67 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2B55611C7D6F8700EB4D67 /* User.swift */; };
 		DA2B55641C7D76B500EB4D67 /* Repository.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2B55631C7D76B500EB4D67 /* Repository.swift */; };
 		DA2B55681C7ED14800EB4D67 /* SiestaTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2B55671C7ED14700EB4D67 /* SiestaTheme.swift */; };
@@ -21,6 +22,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		18CDC2D94A6B11796E5F8136 /* Pods_GithubBrowser.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_GithubBrowser.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A30D9B88A43E86FECB6FED59 /* Pods-GithubBrowser.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GithubBrowser.release.xcconfig"; path = "Pods/Target Support Files/Pods-GithubBrowser/Pods-GithubBrowser.release.xcconfig"; sourceTree = "<group>"; };
+		CC0AB1A69A9C04B0879CFD4C /* Pods-GithubBrowser.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GithubBrowser.debug.xcconfig"; path = "Pods/Target Support Files/Pods-GithubBrowser/Pods-GithubBrowser.debug.xcconfig"; sourceTree = "<group>"; };
 		DA2B55611C7D6F8700EB4D67 /* User.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		DA2B55631C7D76B500EB4D67 /* Repository.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Repository.swift; sourceTree = "<group>"; };
 		DA2B55671C7ED14700EB4D67 /* SiestaTheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SiestaTheme.swift; sourceTree = "<group>"; };
@@ -41,12 +45,30 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				713AB3CBE73243473E91C834 /* Pods_GithubBrowser.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		8AED95D5D78D84DA71FAF1F6 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				18CDC2D94A6B11796E5F8136 /* Pods_GithubBrowser.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		8EAA22C9983411DA11E59936 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				CC0AB1A69A9C04B0879CFD4C /* Pods-GithubBrowser.debug.xcconfig */,
+				A30D9B88A43E86FECB6FED59 /* Pods-GithubBrowser.release.xcconfig */,
+			);
+			name = Pods;
+			sourceTree = "<group>";
+		};
 		DA2B55601C7D6F7B00EB4D67 /* Model */ = {
 			isa = PBXGroup;
 			children = (
@@ -72,6 +94,8 @@
 			children = (
 				DA74623B1B4C768B00406D67 /* Source */,
 				DA74623A1B4C768B00406D67 /* Products */,
+				8EAA22C9983411DA11E59936 /* Pods */,
+				8AED95D5D78D84DA71FAF1F6 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -121,9 +145,12 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = DA74624B1B4C768B00406D67 /* Build configuration list for PBXNativeTarget "GithubBrowser" */;
 			buildPhases = (
+				589B08AB8210E6BCC8924F81 /* 📦 Check Pods Manifest.lock */,
 				DA7462351B4C768B00406D67 /* Sources */,
 				DA7462361B4C768B00406D67 /* Frameworks */,
 				DA7462371B4C768B00406D67 /* Resources */,
+				ABBC5F5CF6B83AF37EB2D67F /* 📦 Embed Pods Frameworks */,
+				DD66E6435D504CAF585B7E20 /* 📦 Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -178,6 +205,54 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		589B08AB8210E6BCC8924F81 /* 📦 Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		ABBC5F5CF6B83AF37EB2D67F /* 📦 Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Embed Pods Frameworks";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-GithubBrowser/Pods-GithubBrowser-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		DD66E6435D504CAF585B7E20 /* 📦 Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "📦 Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-GithubBrowser/Pods-GithubBrowser-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		DA7462351B4C768B00406D67 /* Sources */ = {
@@ -300,6 +375,7 @@
 		};
 		DA74624C1B4C768B00406D67 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = CC0AB1A69A9C04B0879CFD4C /* Pods-GithubBrowser.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = Source/Info.plist;
@@ -312,6 +388,7 @@
 		};
 		DA74624D1B4C768B00406D67 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = A30D9B88A43E86FECB6FED59 /* Pods-GithubBrowser.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				INFOPLIST_FILE = Source/Info.plist;

--- a/Examples/GithubBrowser/GithubBrowser.xcodeproj/project.pbxproj
+++ b/Examples/GithubBrowser/GithubBrowser.xcodeproj/project.pbxproj
@@ -14,7 +14,6 @@
 		DA7462421B4C768B00406D67 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DA7462401B4C768B00406D67 /* Main.storyboard */; };
 		DA7462441B4C768B00406D67 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = DA7462431B4C768B00406D67 /* Assets.xcassets */; };
 		DA7462471B4C768B00406D67 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DA7462451B4C768B00406D67 /* LaunchScreen.storyboard */; };
-		DA7462511B4C781E00406D67 /* Siesta.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA74624F1B4C781E00406D67 /* Siesta.framework */; };
 		DAE2F84A1B94F10500D2AD96 /* GithubAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE2F8441B94F10500D2AD96 /* GithubAPI.swift */; };
 		DAE2F84C1B94F10500D2AD96 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE2F8471B94F10500D2AD96 /* AppDelegate.swift */; };
 		DAE2F84D1B94F10500D2AD96 /* RepositoryListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAE2F8481B94F10500D2AD96 /* RepositoryListViewController.swift */; };
@@ -31,7 +30,6 @@
 		DA7462431B4C768B00406D67 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		DA7462461B4C768B00406D67 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		DA7462481B4C768B00406D67 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		DA74624F1B4C781E00406D67 /* Siesta.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Siesta.framework; path = Carthage/Build/iOS/Siesta.framework; sourceTree = "<group>"; };
 		DAE2F8441B94F10500D2AD96 /* GithubAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GithubAPI.swift; sourceTree = "<group>"; };
 		DAE2F8471B94F10500D2AD96 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		DAE2F8481B94F10500D2AD96 /* RepositoryListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RepositoryListViewController.swift; sourceTree = "<group>"; };
@@ -43,7 +41,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DA7462511B4C781E00406D67 /* Siesta.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -74,7 +71,6 @@
 			isa = PBXGroup;
 			children = (
 				DA74623B1B4C768B00406D67 /* Source */,
-				DA7462521B4C782100406D67 /* Frameworks */,
 				DA74623A1B4C768B00406D67 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -96,14 +92,6 @@
 				DA2DDA771B5984CA00294A72 /* Resources */,
 			);
 			path = Source;
-			sourceTree = "<group>";
-		};
-		DA7462521B4C782100406D67 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-				DA74624F1B4C781E00406D67 /* Siesta.framework */,
-			);
-			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		DAE2F8431B94F10500D2AD96 /* API */ = {
@@ -136,7 +124,6 @@
 				DA7462351B4C768B00406D67 /* Sources */,
 				DA7462361B4C768B00406D67 /* Frameworks */,
 				DA7462371B4C768B00406D67 /* Resources */,
-				DA7462531B4C791D00406D67 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -191,24 +178,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		DA7462531B4C791D00406D67 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"$(PROJECT_DIR)/Carthage/Build/iOS/Siesta.framework",
-				"$(PROJECT_DIR)/Carthage/Build/iOS/SwiftyJSON.framework",
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		DA7462351B4C768B00406D67 /* Sources */ = {
@@ -333,7 +302,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/iOS";
 				INFOPLIST_FILE = Source/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				"OTHER_SWIFT_FLAGS[arch=*]" = "-DDEBUG";
@@ -346,7 +314,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/iOS";
 				INFOPLIST_FILE = Source/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bustoutsolutions.GithubBrowser;

--- a/Examples/GithubBrowser/GithubBrowser.xcworkspace/contents.xcworkspacedata
+++ b/Examples/GithubBrowser/GithubBrowser.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:GithubBrowser.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/Examples/GithubBrowser/Podfile
+++ b/Examples/GithubBrowser/Podfile
@@ -1,0 +1,8 @@
+platform :ios, '9.0'
+
+target 'GithubBrowser' do
+  use_frameworks!
+
+  pod 'Siesta', path: '../..'
+  pod 'SwiftyJSON'
+end

--- a/Examples/GithubBrowser/Podfile.lock
+++ b/Examples/GithubBrowser/Podfile.lock
@@ -1,0 +1,21 @@
+PODS:
+  - Siesta (1.0-beta.6):
+    - Siesta/Core (= 1.0-beta.6)
+  - Siesta/Core (1.0-beta.6)
+  - SwiftyJSON (2.3.2)
+
+DEPENDENCIES:
+  - Siesta (from `../..`)
+  - SwiftyJSON
+
+EXTERNAL SOURCES:
+  Siesta:
+    :path: "../.."
+
+SPEC CHECKSUMS:
+  Siesta: 353fba713b4ce9112c26f6b5038ccebeb897f60b
+  SwiftyJSON: 04ccea08915aa0109039157c7974cf0298da292a
+
+PODFILE CHECKSUM: 1b049ab49e1e4cfa3e646e34135423a20b163fb4
+
+COCOAPODS: 1.0.0


### PR DESCRIPTION
Switching the example project from Carthage to CocoaPods. Reasons:

- Despite its initial promise, Carthage adoption is low — and now looks like it will remain permanently low with SwiftPM coming. Far more users interesting in trying an example project will have CocoaPods installed.
- Carthage has proven inflexible, slow, difficult for new users to set up, and reluctant to adapt to user needs. CocoaPods is a terrifying behemoth, but one that works well.
- CocoaPods makes it easy to test Siesta changes locally in the example project, because it supports local file system dependencies. Carthage does not, and thus requires a push or hackery to test changes. (This shortcoming also forces a redundant checkout with Carthage.)
- This should make `pod try` work properly.

This is for the GithubBrowser example project only. The core Siesta project will continue to use Carthage for the time being.

Objections? Speak now!