### PR TITLE
Cache size limit

### DIFF
--- a/Source/Service.swift
+++ b/Source/Service.swift
@@ -393,4 +393,17 @@ public class Service: NSObject
         {
         wipeResources { predicate($0.url) }
         }
+
+    // MARK: General Configuration
+
+    /**
+      Soft limit on the number of resources cached in memory. If the internal cache size exceeds this limit, Siesta
+      flushes all unused resources. Note that any resources still in use — i.e. retained outside of Siesta — will remain
+      in the cache, no matter how many there are.
+    */
+    public var cachedResourceCountLimit: Int
+        {
+        get { return resourceCache.countLimit }
+        set { resourceCache.countLimit = newValue }
+        }
     }

--- a/Source/Support/WeakCache.swift
+++ b/Source/Support/WeakCache.swift
@@ -23,6 +23,11 @@ internal final class WeakCache<K: Hashable, V: AnyObject>
     private var entriesByKey = [K : WeakCacheEntry<V>]()
     private var lowMemoryObserver: AnyObject? = nil
 
+    internal var countLimit = 2048
+        {
+        didSet { checkLimit() }
+        }
+
     init()
         {
         lowMemoryObserver =
@@ -46,10 +51,17 @@ internal final class WeakCache<K: Hashable, V: AnyObject>
         {
         return entriesByKey[key]?.value ??
             {
+            checkLimit()
             let value = onMiss()
             entriesByKey[key] = WeakCacheEntry(value)
             return value
             }()
+        }
+
+    private func checkLimit()
+        {
+        if entriesByKey.count >= countLimit
+            { flushUnused() }
         }
 
     func flushUnused()

--- a/Tests/ServiceSpec.swift
+++ b/Tests/ServiceSpec.swift
@@ -149,6 +149,20 @@ class ServiceSpec: SiestaSpec
                 expect(service().resource("/foo").child("oogle").child("baz").relative("../bar"))
                      === service().resource("/foo/bar")
                 }
+
+            it("releases unused resources when cache limit exceeded")
+                {
+                service().cachedResourceCountLimit = 10
+                let retainedResource = service().resource("/retained")
+                weak var unretainedResource = service().resource("/unretained")
+                expect(unretainedResource).notTo(beNil())
+
+                for i in 0 ..< 9
+                    { _ = service().resource("/\(i)") }
+
+                expect(service().resource("/retained")) === retainedResource
+                expect(unretainedResource).to(beNil())
+                }
             }
 
         describe("configuration")


### PR DESCRIPTION
Added a naive cache limit that removes all unused resources (i.e. not retained outside of Siesta) from the `Service`’s internal cache. Default limit is 2048 resources.

This fixes #31.

We might want to add some more sophisticated cache eviction policy in the future, but this should suffice for now.