### PR TITLE
Pipeline api tweaks

### DIFF
--- a/Source/Pipeline.swift
+++ b/Source/Pipeline.swift
@@ -282,6 +282,21 @@ public struct PipelineStage
     public var cache: EntityCache?
     }
 
+extension PipelineStage
+    {
+    /**
+      Ways of modifying a stage’s transformers. Used by `Service.configureTransformer(...)`.
+    */
+    public enum MutationAction
+        {
+        /// Remove all existing transformers and add the new one.
+        case replaceExisting
+
+        /// Add the new transformer at the end of the existing ones.
+        case appendToExisting
+        }
+    }
+
 /**
   An unique identifier for a `PipelineStage` within a `Pipeline`. Transformers and stages have no intrinsic notion of
   identity or equality, so these keys are the only way to alter transformers after they’re configured.

--- a/Source/Request/NetworkRequest.swift
+++ b/Source/Request/NetworkRequest.swift
@@ -186,7 +186,7 @@ internal final class NetworkRequest: RequestWithDefaultCallbacks, CustomDebugStr
         if shouldIgnoreResponse(newInfo.response)
             { return }
 
-        debugLog(.NetworkDetails, ["Response after transformer pipeline:", newInfo.isNew ? " (new data)" : " (data unchanged)", newInfo.response.dump("   ")])
+        debugLog(.NetworkDetails, ["Response after transformer pipeline:", newInfo.isNew ? " (new data)" : " (data unchanged)", newInfo.response.dump()])
 
         progressTracker.complete()
 

--- a/Source/ResponseTransformer.swift
+++ b/Source/ResponseTransformer.swift
@@ -46,7 +46,7 @@ public extension ResponseTransformer
     /// Helper to log a transformation. Call this in your custom transformer.
     public func logTransformation(result: Response) -> Response
         {
-        debugLog(.ResponseProcessing, [self, "→", result])
+        debugLog(.ResponseProcessing, ["Applied transformer:", self, "\n    → ", result])
         return result
         }
     }
@@ -143,10 +143,10 @@ public struct ResponseContentTransformer<InputContentType,OutputContentType>: Re
         switch response
             {
             case .Success(let entity):
-                return processEntity(entity)
+                return logTransformation(processEntity(entity))
 
             case .Failure(let error):
-                return processError(error)
+                return logTransformation(processError(error))
             }
         }
 
@@ -160,13 +160,12 @@ public struct ResponseContentTransformer<InputContentType,OutputContentType>: Re
 
         guard let typedContent = entity.content as? InputContentType else
             {
-            return logTransformation(
-                .Failure(Error(
-                    userMessage: NSLocalizedString("Cannot parse server response", comment: "userMessage"),
-                    cause: Error.Cause.WrongTypeInTranformerPipeline(
-                        expectedType: debugStr(InputContentType.self),
-                        actualType: debugStr(entity.content.dynamicType),
-                        transformer: self))))
+            return .Failure(Error(
+                userMessage: NSLocalizedString("Cannot parse server response", comment: "userMessage"),
+                cause: Error.Cause.WrongTypeInTranformerPipeline(
+                    expectedType: debugStr(InputContentType.self),
+                    actualType: debugStr(entity.content.dynamicType),
+                    transformer: self)))
             }
 
         do  {
@@ -183,7 +182,7 @@ public struct ResponseContentTransformer<InputContentType,OutputContentType>: Re
                 ?? Error(
                     userMessage: NSLocalizedString("Cannot parse server response", comment: "userMessage"),
                     cause: error)
-            return logTransformation(.Failure(siestaError))
+            return .Failure(siestaError)
             }
         }
 

--- a/Source/ResponseTransformer.swift
+++ b/Source/ResponseTransformer.swift
@@ -119,7 +119,7 @@ public struct ResponseContentTransformer<InputContentType,OutputContentType>: Re
       - Parameter skipWhenEntityMatchesOutputType:
           When true, if the input content already matches `OutputContentType`, the transformer does nothing.
           When false, the tranformer always attempts to parse its input.
-          Default is true.
+          Default is false.
       - Parameter transformErrors:
           When true, apply the transformation to `Error.content` (if present).
           When false, only parse success responses.
@@ -128,7 +128,7 @@ public struct ResponseContentTransformer<InputContentType,OutputContentType>: Re
           The transformation logic.
     */
     public init(
-            skipWhenEntityMatchesOutputType: Bool = true,
+            skipWhenEntityMatchesOutputType: Bool = false,
             transformErrors: Bool = false,
             processor: Processor)
         {

--- a/Source/Service.swift
+++ b/Source/Service.swift
@@ -284,9 +284,7 @@ public class Service: NSObject
                 { $0.config.pipeline[stage].removeTransformers() }
 
             $0.config.pipeline[stage].add(
-                ResponseContentTransformer(
-                    skipWhenEntityMatchesOutputType: false,
-                    processor: contentTransform))
+                ResponseContentTransformer(processor: contentTransform))
             }
         }
 

--- a/Source/Service.swift
+++ b/Source/Service.swift
@@ -260,7 +260,7 @@ public class Service: NSObject
     public final func configureTransformer<I,O>(
             pattern: ConfigurationPatternConvertible,
             atStage stage: PipelineStageKey = .model,
-            replaceExisting: Bool = true,
+            action: PipelineStage.MutationAction = .replaceExisting,
             requestMethods: [RequestMethod]? = nil,
             description: String? = nil,
             contentTransform: ResponseContentTransformer<I,O>.Processor)
@@ -280,11 +280,13 @@ public class Service: NSObject
 
         configure(pattern, requestMethods: requestMethods, description: description ?? defaultDescription())
             {
-            if replaceExisting
+            if action == .replaceExisting
                 { $0.config.pipeline[stage].removeTransformers() }
 
             $0.config.pipeline[stage].add(
-                ResponseContentTransformer(processor: contentTransform))
+                ResponseContentTransformer(
+                    skipWhenEntityMatchesOutputType: false,
+                    processor: contentTransform))
             }
         }
 

--- a/Tests/PipelineSpec.swift
+++ b/Tests/PipelineSpec.swift
@@ -17,7 +17,7 @@ class PipelineSpec: ResourceSpecBase
         {
         func appender(word: String) -> ResponseContentTransformer<Any,String>
             {
-            return ResponseContentTransformer(skipWhenEntityMatchesOutputType: false)
+            return ResponseContentTransformer
                 {
                 let stringContent = $0.content as? String ?? ""
                 guard !stringContent.containsString("error on \(word)") else

--- a/Tests/ResponseDataHandlingSpec.swift
+++ b/Tests/ResponseDataHandlingSpec.swift
@@ -80,12 +80,12 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                 expect(cause?.encodingName) == "utf-8"
                 }
 
-            it("bypasses response if another transformer already made it a string")
+            it("report an error if another transformer already made it a string")
                 {
                 service().configure
                     { $0.config.pipeline[.decoding].add(TestTransformer()) }
-                stubText("blah blah", contentType: "text/plain")
-                expect(resource().text) == "<non-string> processed"
+                stubText("blah blah", contentType: "text/plain", expectSuccess: false)
+                expect(resource().latestError?.cause is Error.Cause.WrongTypeInTranformerPipeline) == true
                 }
 
             it("transforms error responses")
@@ -369,19 +369,6 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                     expect(resource().latestData).to(beNil())
 
                     expect(resource().latestError?.cause is Error.Cause.WrongTypeInTranformerPipeline) == true
-                    }
-
-                it("infers output type and skips content if already transformed")
-                    {
-                    configureModelTransformer()
-                    service().configureTransformer("**", atStage: .cleanup)
-                        {
-                        (content: String, entity: Entity) in
-                        return TestModel(name: "should not be called")
-                        }
-                    stubText("Fred")
-                    let model: TestModel? = resource().typedContent()
-                    expect(model?.name) == "Fred"
                     }
 
                 it("can throw a custom error")

--- a/Tests/ResponseDataHandlingSpec.swift
+++ b/Tests/ResponseDataHandlingSpec.swift
@@ -409,7 +409,7 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                     expect(resource().latestError?.cause is CustomError) == true
                     }
 
-                it("replaces previously configured model transformers")
+                it("replaces previously configured model transformers by default")
                     {
                     configureModelTransformer()
                     service().configureTransformer("**")
@@ -418,6 +418,22 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                     stubText("wasabi")
                     let model: TestModel? = resource().typedContent()
                     expect(model?.name) == "extra wasabi"
+                    }
+
+                it("can append to previously configured model transformers")
+                    {
+                    configureModelTransformer()
+                    service().configureTransformer("**", action: .appendToExisting)
+                        {
+                        (content: TestModel, entity: Entity) -> TestModel in
+                        var model: TestModel = content
+                        model.name += " peas"
+                        return model
+                        }
+
+                    stubText("wasabi")
+                    let model: TestModel? = resource().typedContent()
+                    expect(model?.name) == "wasabi peas"
                     }
 
                 func stubTextRequest(string: String, method: RequestMethod) -> Entity
@@ -544,7 +560,7 @@ private class TestTransformer: ResponseTransformer
 
 private struct TestModel
     {
-    let name: String
+    var name: String
 
     init(name: String)
         { self.name = name }


### PR DESCRIPTION
Some small but breaking changes:

1. By default, `ResponseContentTransformer` used to skip the transform when the input type already matched the output type. (For example, if the transformer returned a string but there was already a string from upstream in the pipeline, it wouldn’t run.) This behavior is useful but confusing, and shouldn’t be the default.
2. Enum for clearer pipeline config actions:
  - Before: 

    ```swift
    configureTransformer("/foo", replacingExisting: true)
    configureTransformer("/foo", replacingExisting: false)
    ```

  - After:

    ```swift
    configureTransformer("/foo", action: .replaceExisting)
    configureTransformer("/foo", action: .appendToExisting)
    ```

This PR also includes more helpful logging of exactly what happens to a response when it runs through the transformer pipeline.