### PR TITLE
Overlay state can also change when it stops observing

### DIFF
--- a/Source/UI/ResourceStatusOverlay.swift
+++ b/Source/UI/ResourceStatusOverlay.swift
@@ -247,6 +247,7 @@ public class ResourceStatusOverlay: UIView, ResourceObserver
     public func stoppedObservingResource(resource: Resource)
         {
         observedResources = observedResources.filter { $0 !== resource }
+        updateDisplay()
         }
 
     private func showError(error: Error)


### PR DESCRIPTION
Fixed: the status overlay shows a spinner or error message indefinitely if is stops observing a resource that’s in a loading/error state, but doesn’t start observing a new one.