### PR TITLE
Interchangeable NSURL / String

### DIFF
--- a/Source/Support/NSURL+Siesta.swift
+++ b/Source/Support/NSURL+Siesta.swift
@@ -8,6 +8,26 @@
 
 import Foundation
 
+/// Allows interchangeable use of `String` and `NSURL` in calls that need a URL.
+public protocol URLConvertible
+    {
+    var url: NSURL? { get }
+    }
+
+extension String: URLConvertible
+    {
+    /// Returns the URL represented by this string, if it is a valid URL.
+    public var url: NSURL?
+        { return NSURL(string: self) }
+    }
+
+extension NSURL: URLConvertible
+    {
+    /// Returns self.
+    public var url: NSURL?
+        { return self }
+    }
+
 internal extension NSURL
     {
     @warn_unused_result

--- a/Source/Support/Siesta-ObjC.swift
+++ b/Source/Support/Siesta-ObjC.swift
@@ -112,6 +112,17 @@ public class _objc_Error: NSObject
         }
     }
 
+public extension Service
+    {
+    @objc(resourceWithAbsoluteURL:)
+    public final func _objc_resourceWithAbsoluteURL(absoluteURL url: NSURL?) -> Resource
+        { return resource(absoluteURL: url) }
+
+    @objc(resourceWithAbsoluteURLString:)
+    public final func _objc_resourceWithAbsoluteURLString(absoluteURL url: String?) -> Resource
+        { return resource(absoluteURL: url) }
+    }
+
 public extension Resource
     {
     @objc(latestData)


### PR DESCRIPTION
Allow both `String` and `NSURL` as args for `Service.init(baseURL:)` and `Service.resource(absoluteURL:)`.

Fixes #74. Thanks to @jordanpwood for pointing out the need!