### PR TITLE
Percent-encode plus signs when using withParam

### DIFF
--- a/Source/Support/NSURL+Siesta.swift
+++ b/Source/Support/NSURL+Siesta.swift
@@ -61,6 +61,9 @@ internal extension NSURL
 
         components.queryItems = newItems.isEmpty ? nil : newItems
 
+        components.percentEncodedQuery = components.percentEncodedQuery?
+            .stringByReplacingOccurrencesOfString("+", withString: "%2B")
+
         return components.URL
         }
     }

--- a/Tests/ResourcePathsSpec.swift
+++ b/Tests/ResourcePathsSpec.swift
@@ -150,8 +150,8 @@ class ResourcePathsSpec: ResourceSpecBase
 
             it("escapes params")
                 {
-                expect(resource().withParam("fo=o", "ba r").url.absoluteString)
-                     == "https://zingle.frotz/v1/a/b?fo%3Do=ba%20r"
+                expect(resource().withParam("fo=o", "ba r+baz").url.absoluteString)
+                     == "https://zingle.frotz/v1/a/b?fo%3Do=ba%20r%2Bbaz"
                 }
 
             let resourceWithParams = specVar { resource().withParam("foo", "bar").withParam("zoogle", "oogle") }


### PR DESCRIPTION
Possible fix of #96 

Spaces are left with current behaviour of encoding to %20, plus signs are encoded as %2B.

The replacement must be done after building `NSURLComponents.queryItems`, otherwise double encoding occurs