### PR TITLE
Content transformer improvements

### DIFF
--- a/Source/Service.swift
+++ b/Source/Service.swift
@@ -275,6 +275,7 @@ public class Service: NSObject
             atStage stage: PipelineStageKey = .model,
             action: PipelineStage.MutationAction = .replaceExisting,
             onInputTypeMismatch mismatchAction: InputTypeMismatchAction = .Error,
+            transformErrors: Bool = false,
             description: String? = nil,
             contentTransform: ResponseContentTransformer<I,O>.Processor)
         {
@@ -299,6 +300,7 @@ public class Service: NSObject
             $0.config.pipeline[stage].add(
                 ResponseContentTransformer(
                     onInputTypeMismatch: mismatchAction,
+                    transformErrors: transformErrors,
                     processor: contentTransform))
             }
         }

--- a/Source/Service.swift
+++ b/Source/Service.swift
@@ -271,9 +271,10 @@ public class Service: NSObject
     */
     public final func configureTransformer<I,O>(
             pattern: ConfigurationPatternConvertible,
+            requestMethods: [RequestMethod]? = nil,
             atStage stage: PipelineStageKey = .model,
             action: PipelineStage.MutationAction = .replaceExisting,
-            requestMethods: [RequestMethod]? = nil,
+            onInputTypeMismatch mismatchAction: InputTypeMismatchAction = .Error,
             description: String? = nil,
             contentTransform: ResponseContentTransformer<I,O>.Processor)
         {
@@ -296,7 +297,9 @@ public class Service: NSObject
                 { $0.config.pipeline[stage].removeTransformers() }
 
             $0.config.pipeline[stage].add(
-                ResponseContentTransformer(processor: contentTransform))
+                ResponseContentTransformer(
+                    onInputTypeMismatch: mismatchAction,
+                    processor: contentTransform))
             }
         }
 

--- a/Source/Support/Ω_Deprecations.swift
+++ b/Source/Support/Ω_Deprecations.swift
@@ -20,10 +20,17 @@ extension Request
         }
     }
 
-// Deprecated in 1.0-beta.9
-
-extension Error.Cause
+extension ResponseContentTransformer
     {
-    @available(*, deprecated=0.99, renamed="WrongInputTypeInTranformerPipeline")
-    public typealias WrongTypeInTranformerPipeline = Error.Cause.WrongInputTypeInTranformerPipeline
+    @available(*, deprecated=0.99, message="skipWhenEntityMatchesOutputType: removed in favor of onInputTypeMismatch:", renamed="init(onInputTypeMismatch:transformErrors:processor:)")
+    public init(
+            skipWhenEntityMatchesOutputType: Bool,
+            transformErrors: Bool = false,
+            processor: Processor)
+        {
+        self.init(
+            onInputTypeMismatch: skipWhenEntityMatchesOutputType ? .SkipIfOutputTypeMatches : .Error,
+            transformErrors: transformErrors,
+            processor: processor)
+        }
     }

--- a/Tests/ResponseDataHandlingSpec.swift
+++ b/Tests/ResponseDataHandlingSpec.swift
@@ -351,7 +351,7 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                     expect(model?.name) == "Fred"
                     }
 
-                it("leaves errors untouched")
+                it("leaves errors untouched by default")
                     {
                     configureModelTransformer()
                     stubRequest(resource, "GET").andReturn(500)
@@ -360,6 +360,18 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                     awaitFailure(resource().load())
                     expect(resource().latestData).to(beNil())
                     expect(resource().latestError?.text) == "I am not a model"
+                    }
+
+                it("can transform errors")
+                    {
+                    service().configureTransformer("**", transformErrors: true)
+                        { TestModel(name: $0.content) }
+                    stubRequest(resource, "GET").andReturn(500)
+                        .withHeader("Content-Type", "text/plain")
+                        .withBody("Fred T. Error")
+                    awaitFailure(resource().load())
+                    let model: TestModel? = resource().latestError?.typedContent()
+                    expect(model?.name) == "Fred T. Error"
                     }
 
                 context("with mismatched input type")


### PR DESCRIPTION
# Background

Siesta’s content transformers currently provide a `skipWhenEntityMatchesOutputType:` option, which causes the pipeline to skip a transformer if the type coming down the pipeline already matches the output type.

This behavior is immensely confusing. For example, when it’s enabled:

- If you write a `String` → `String` transformer, it will skip any `String` input — and thus will only run if it’s going to fail.
- If you write a transformer whose output type is `Any`, it will _never_ run.

The original intent was to support catch-all transformers that take heterogenous upstream content and normalize it to some uniform downstream form. For example, you might want to add a transformer that creates a `FooModel` from JSON and another that creates it from XML. It’s a nice idea. The current solution, however, is a mistake.

# New Behavior

This PR removes the old behavior in favor of a new `onInputTypeMismatch:` option, which is different in two ways:

- It examines whether the content coming down the pipeline matches the content transformer’s _input_ type, not its _output_ type.
- Instead of a boolean, it provides three possible behaviors: `Error`, `Skip`, and `SkipIfOutputTypeMatches`. That last one is close to the old behavior, but eliminates some of the confusing cases by only coming into play if the input type was wrong. The default is `Error`.

I think this approach will play out much better. In the `FooModel` example above, you might configure the pipeline like this:

    service.configureTransformer(onInputTypeMismatch: .Skip) {
      FooModel(xml: $0.content)
    }

    service.configureTransformer(onInputTypeMismatch: .SkipIfOutputTypeMatches) {
      FooModel(json: $0.content)
    }

If the upstream pipeline produces XML, it runs the first transformer and skips the second.

If the upstream pipeline produces JSON, it skips the first transformer and runs the second.

If the upstream pipeline produces neither, it skips the first transformer and the second produces a “wrong input type” error.