### PR TITLE
Explicit request start

### DIFF
--- a/Source/Siesta/Request/NetworkRequest.swift
+++ b/Source/Siesta/Request/NetworkRequest.swift
@@ -102,9 +102,7 @@ internal final class NetworkRequest: RequestWithDefaultCallbacks, CustomDebugStr
 
     func repeated() -> Request
         {
-        let req = NetworkRequest(resource: resource, requestBuilder: requestBuilder)
-        req.start()
-        return req
+        return NetworkRequest(resource: resource, requestBuilder: requestBuilder)
         }
 
     // MARK: Callbacks

--- a/Source/Siesta/Request/NetworkRequest.swift
+++ b/Source/Siesta/Request/NetworkRequest.swift
@@ -53,7 +53,10 @@ internal final class NetworkRequest: RequestWithDefaultCallbacks, CustomDebugStr
         dispatch_assert_main_queue()
 
         guard self.networking == nil else
-            { fatalError("NetworkRequest.start() called twice") }
+            {
+            debugLog(.NetworkDetails, [requestDescription, "already started"])
+            return
+            }
 
         guard !wasCancelled else
             {

--- a/Source/Siesta/Request/Request.swift
+++ b/Source/Siesta/Request/Request.swift
@@ -72,6 +72,19 @@ public protocol Request: class
     func onFailure(callback: Error -> Void) -> Self
 
     /**
+      Immediately start this request if it was deferred. Does nothing if the request is already started.
+
+      You rarely need to call this method directly:
+
+      - Any request you receive from `Resource.request(...)` or `Resource.load()` is already started.
+      - Requests start automatically when you use `RequestChainAction.PassTo` in a chain.
+
+      When do you need this method, then? It’s rare. `Configuration.decorateRequests` can defer a request by hanging on
+      to it while returning a different request. You can use this method to manually start a request deferred this way.
+    */
+    func start()
+
+    /**
       True if the request has received and handled a server response, encountered a pre-request client-side side error,
       or been cancelled.
     */

--- a/Source/Siesta/Request/RequestChaining.swift
+++ b/Source/Siesta/Request/RequestChaining.swift
@@ -111,12 +111,18 @@ internal final class RequestChain: RequestWithDefaultCallbacks
                 responseCallbacks.notifyOfCompletion(customResponseInfo)
 
             case .PassTo(let request):
+                request.start()  // Necessary if we are passing to deferred original request
                 request.onCompletion
                     { self.responseCallbacks.notifyOfCompletion($0) }
             }
         }
 
     typealias ActionCallback = ResponseInfo -> RequestChainAction
+
+    func start()
+        {
+        wrappedRequest.start()
+        }
 
     var isCompleted: Bool
         {

--- a/Source/Siesta/Request/RequestCreation.swift
+++ b/Source/Siesta/Request/RequestCreation.swift
@@ -204,6 +204,8 @@ private final class FailedRequest: RequestWithDefaultCallbacks
         return self
         }
 
+    func start() { }
+
     func cancel()
         { dispatch_assert_main_queue() }
 

--- a/Source/Siesta/Resource/Resource.swift
+++ b/Source/Siesta/Resource/Resource.swift
@@ -218,18 +218,14 @@ public final class Resource: NSObject
 
         // Optionally decorate the request
 
-        var rawReq = NetworkRequest(resource: self, requestBuilder: requestBuilder)
+        let rawReq = NetworkRequest(resource: self, requestBuilder: requestBuilder)
         let req = rawReq.config.requestDecorators.reduce(rawReq as Request)
             { req, decorate in decorate(self, req) }
-
-        // Start the underlying request, unless the decorators discarded it
-
-        if !isUniquelyReferencedNonObjC(&rawReq)
-            { rawReq.start() }
 
         // Track the fully decorated request
 
         trackRequest(req, using: &allRequests)
+        req.start()
         return req
         }
 


### PR DESCRIPTION
#98 tried to avoid making apps ever have to explicitly start requests by using a too-clever hack involving `isUniquelyReferenced`. This was a bad idea: it was confusing, and precluded several kinds of request decoration one might want to do.

This PR adds a `start()` method to the `Request` protocol. Under most circumstances, apps will not have to call it. Siesta will still automatically start requests in two situations:

- `Resource.request(…)` (and thus `load()` and `loadIfNeeded()` as well) will start whatever request comes out of the configured decorators.
- `RequestChainAction.PassTo` starts the returned request.

Manual start is useful in two cases:

- A request decorator may replace original request A with replacement request B, but still hold on to A. In this case, B is automatically started, but A is not. This allows you to delay the first attempt of a request.
- `Request.repeated()` no longer returns an already-started request. This allows for delayed retries.