### PR TITLE
Lazy cache read

### DIFF
--- a/Source/Siesta/Resource/ResourceObserver.swift
+++ b/Source/Siesta/Resource/ResourceObserver.swift
@@ -165,6 +165,7 @@ public extension Resource
                 // have to use observers[i] instead of loop var to
                 // make mutator actually change struct in place in array
                 observers[i].addOwner(owner)
+                observersChanged()
                 return self
                 }
             }
@@ -173,6 +174,7 @@ public extension Resource
         newEntry.addOwner(owner)
         observers.append(newEntry)
         observer.resourceChanged(self, event: .observerAdded)
+        observersChanged()
         return self
         }
 
@@ -247,6 +249,9 @@ public extension Resource
             debugLog(.observers, [self, "removing observer whose owners are all gone:", entry])
             entry.observer?.stoppedObserving(resource: self)
             }
+
+        if !removed.isEmpty
+            { observersChanged() }
         }
     }
 

--- a/Tests/PipelineSpec.swift
+++ b/Tests/PipelineSpec.swift
@@ -140,9 +140,9 @@ class PipelineSpec: ResourceSpecBase
                     {
                     let emptyCache = TestCache("empty")
                     configureCache(emptyCache, at: .cleanup)
-                    _ = resource()
+                    _ = resource().latestData
                     waitForCacheRead(emptyCache)
-                    expect(resource().text) == ""
+                    expect(resource().latestData).to(beNil())
                     }
 
                 it("ignores cached data if resource populated before cache read completes")

--- a/Tests/ServiceSpec.swift
+++ b/Tests/ServiceSpec.swift
@@ -418,6 +418,12 @@ class ServiceSpec: SiestaSpec
                 service().invalidateConfiguration()
                 expect(resource0().configuration.expirationTime) == 4
                 }
+
+            it("is not computed when traversing resources but not using them")
+                {
+                service().configure { _ in fatalError("should not be called") }
+                _ = service().resource("/").child("foo/baz").relative("../bar").withParam("x", "y")
+                }
             }
 
         describe("wipeResources()")


### PR DESCRIPTION
Siesta currently computes resource configuration as soon as you get a `Resource` instance. This means that if you do:

    service.resource("foo").child("bar").withParam("x", "y")

…you’ll see configuration computed for `/foo` and `/foo/bar` even though they’re never used except for path traversal.

**It’s a major log clog.** Getting rid of the minor performance penalty of unneeded configuration would also be nice.

These unnecessary config computations happen because Siesta immediate checks for cached data when `Resource` is instantiated. **This PR moves that check to the first call to `latestData` or `addObserver(…)`.**

The only effect of this visible from outside of Siesta is that cache reads may happen slightly later. In particular, if you got a `Resource` instance but then delayed your first check of `latestData` (or derivatives of it such as `.json` or `.typedContent()`), you might now see nil where before you saw data. You shouldn’t rely on cached data being present after any particular delay — checking data without either observing or polling the resource is a race condition — so I think this change is safe.

24ish-hour comment period now open.