### PR TITLE
Logging improvements

### DIFF
--- a/Examples/GithubBrowser/Source/UI/UserViewController.swift
+++ b/Examples/GithubBrowser/Source/UI/UserViewController.swift
@@ -62,7 +62,7 @@ class UserViewController: UIViewController, UISearchBarDelegate, ResourceObserve
     }
 
     override var preferredStatusBarStyle: UIStatusBarStyle {
-        return .lightContent;
+        return .lightContent
     }
 
     override func viewDidLayoutSubviews() {

--- a/Source/Siesta/ConfigurationPatternConvertible.swift
+++ b/Source/Siesta/ConfigurationPatternConvertible.swift
@@ -62,7 +62,7 @@ extension String: ConfigurationPatternConvertible
         // Otherwise, interpret pattern as relative to baseURL.
 
         let resolvedPattern: String
-        if let prefix = service.baseURL?.absoluteString , !containsRegex("^[a-z]+:")
+        if !containsRegex("^[a-z]+:"), let prefix = service.baseURL?.absoluteString
             { resolvedPattern = prefix + stripPrefix("/") }
         else
             { resolvedPattern = self }

--- a/Source/Siesta/Pipeline/PipelineConfiguration.swift
+++ b/Source/Siesta/Pipeline/PipelineConfiguration.swift
@@ -69,7 +69,7 @@ public struct Pipeline
                 .map { key, _ in key }
             let missingStages = Set(nonEmptyStages).subtracting(newValue)
             if !missingStages.isEmpty
-                { debugLog(.responseProcessing, ["WARNING: Stages", missingStages, "configured but not present in custom pipeline order, will be ignored:", newValue]) }
+                { debugLog(.pipeline, ["WARNING: Stages", missingStages, "configured but not present in custom pipeline order, will be ignored:", newValue]) }
             }
         }
 

--- a/Source/Siesta/Pipeline/PipelineConfiguration.swift
+++ b/Source/Siesta/Pipeline/PipelineConfiguration.swift
@@ -131,7 +131,7 @@ public struct Pipeline
 */
 public struct PipelineStage
     {
-    private var transformers: [ResponseTransformer] = []
+    internal private(set) var transformers: [ResponseTransformer] = []
     internal var cacheBox: CacheBox?
 
     /**

--- a/Source/Siesta/Pipeline/PipelineConfiguration.swift
+++ b/Source/Siesta/Pipeline/PipelineConfiguration.swift
@@ -39,7 +39,7 @@ import Foundation
 */
 public struct Pipeline
     {
-    internal var stages: [PipelineStageKey:PipelineStage] = [:]
+    private var stages: [PipelineStageKey:PipelineStage] = [:]
 
     /**
       The order in which the pipeline’s stages run. The default order is:

--- a/Source/Siesta/Pipeline/PipelineProcessing.swift
+++ b/Source/Siesta/Pipeline/PipelineProcessing.swift
@@ -113,11 +113,13 @@ internal extension Pipeline
 internal struct CacheBox
     {
     fileprivate let buildEntry: (Resource) -> (CacheEntryProtocol?)
+    internal let description: String
 
     init?<T: EntityCache>(cache: T?)
         {
         guard let cache = cache else { return nil }
         buildEntry = { CacheEntry(cache: cache, resource: $0) }
+        description = String(describing: type(of: cache))
         }
     }
 

--- a/Source/Siesta/Pipeline/PipelineProcessing.swift
+++ b/Source/Siesta/Pipeline/PipelineProcessing.swift
@@ -11,7 +11,7 @@ import Foundation
 internal extension Pipeline
     {
     private var stagesInOrder: [PipelineStage]
-        { return order.flatMap { stages[$0] } }
+        { return order.flatMap { self[$0] } }
 
     private typealias StageAndEntry = (PipelineStage, CacheEntryProtocol?)
 

--- a/Source/Siesta/Pipeline/PipelineProcessing.swift
+++ b/Source/Siesta/Pipeline/PipelineProcessing.swift
@@ -27,7 +27,15 @@ internal extension Pipeline
         let stagesAndEntries = self.stagesAndEntries(for: resource)
 
         // Return deferred processor to run on background queue
-        return { self.processAndCache(rawResponse, using: stagesAndEntries) }
+        return
+            {
+            let result = self.processAndCache(rawResponse, using: stagesAndEntries)
+
+            debugLog(.pipeline,       ["  └╴Response after pipeline:", result.summary()])
+            debugLog(.networkDetails, ["    Details:", result.dump("      ")])
+
+            return result
+            }
         }
 
     // Runs on a background queue
@@ -46,7 +54,7 @@ internal extension Pipeline
             if case .success(let entity) = output,
                let cacheEntry = cacheEntry
                 {
-                debugLog(.cache, ["Caching entity with", type(of: entity.content), "content in", cacheEntry])
+                debugLog(.cache, ["  ├╴Caching entity with", type(of: entity.content), "content in", cacheEntry])
                 cacheEntry.write(entity)
                 }
 

--- a/Source/Siesta/Pipeline/ResponseTransformer.swift
+++ b/Source/Siesta/Pipeline/ResponseTransformer.swift
@@ -53,7 +53,7 @@ public extension ResponseTransformer
     /// Helper to log a transformation. Call this in your custom transformer.
     public func logTransformation(_ result: Response) -> Response
         {
-        debugLog(.pipeline, ["Applied transformer:", self, "\n    → ", result])
+        debugLog(.pipeline, ["  ├╴Applied transformer:", self, "\n  │ ↳", result.summary()])
         return result
         }
     }
@@ -92,9 +92,9 @@ internal struct ContentTypeMatchTransformer: ResponseTransformer
                 contentType = error.entity?.contentType
             }
 
-        if let contentType = contentType , contentTypeMatcher.matches(contentType)
+        if let contentType = contentType, contentTypeMatcher.matches(contentType)
             {
-            debugLog(.pipeline, [delegate, "matches content type", debugStr(contentType)])
+            debugLog(.pipeline, ["  ├╴Transformer", self, "matches content type", debugStr(contentType)])
             return delegate.process(response)
             }
         else

--- a/Source/Siesta/Pipeline/ResponseTransformer.swift
+++ b/Source/Siesta/Pipeline/ResponseTransformer.swift
@@ -45,7 +45,7 @@ public extension ResponseTransformer
     /// Helper to log a transformation. Call this in your custom transformer.
     public func logTransformation(_ result: Response) -> Response
         {
-        debugLog(.responseProcessing, ["Applied transformer:", self, "\n    → ", result])
+        debugLog(.pipeline, ["Applied transformer:", self, "\n    → ", result])
         return result
         }
     }
@@ -84,7 +84,7 @@ internal struct ContentTypeMatchTransformer: ResponseTransformer
 
         if let contentType = contentType , contentTypeMatcher.matches(contentType)
             {
-            debugLog(.responseProcessing, [delegate, "matches content type", debugStr(contentType)])
+            debugLog(.pipeline, [delegate, "matches content type", debugStr(contentType)])
             return delegate.process(response)
             }
         else
@@ -160,7 +160,7 @@ public struct ResponseContentTransformer<InputContentType,OutputContentType>: Re
                 case .skip,
                      .skipIfOutputTypeMatches where entity.content is OutputContentType:
 
-                    debugLog(.responseProcessing, [self, "skipping transformer because its mismatch rule is", mismatchAction, ", and it expected content of type", InputContentType.self, "but got a", type(of: entity.content)])
+                    debugLog(.pipeline, [self, "skipping transformer because its mismatch rule is", mismatchAction, ", and it expected content of type", InputContentType.self, "but got a", type(of: entity.content)])
                     return .success(entity)
 
                 case .error, .skipIfOutputTypeMatches:
@@ -207,7 +207,7 @@ public struct ResponseContentTransformer<InputContentType,OutputContentType>: Re
                     error.entity = errorDataTransformed
 
                 case .failure(let error):
-                    debugLog(.responseProcessing, ["Unable to parse error response body; will leave error body unprocessed:", error])
+                    debugLog(.pipeline, ["Unable to parse error response body; will leave error body unprocessed:", error])
                 }
             }
         return .failure(error)

--- a/Source/Siesta/Request/NetworkRequest.swift
+++ b/Source/Siesta/Request/NetworkRequest.swift
@@ -250,7 +250,7 @@ internal final class NetworkRequest: RequestWithDefaultCallbacks, CustomDebugStr
 
     var debugDescription: String
         {
-        return "Siesta.Request:"
+        return "Request:"
             + String(UInt(bitPattern: ObjectIdentifier(self)), radix: 16)
             + "("
             + requestDescription

--- a/Source/Siesta/Request/NetworkRequest.swift
+++ b/Source/Siesta/Request/NetworkRequest.swift
@@ -128,7 +128,7 @@ internal final class NetworkRequest: RequestWithDefaultCallbacks, CustomDebugStr
 
         underlyingNetworkRequestCompleted = true
 
-        debugLog(.network, [underlyingResponse?.statusCode ?? error, "←", requestDescription])
+        debugLog(.network, ["Response: ", underlyingResponse?.statusCode ?? error, "←", requestDescription])
         debugLog(.networkDetails, ["Raw response headers:", underlyingResponse?.allHeaderFields])
         debugLog(.networkDetails, ["Raw response body:", body?.count ?? 0, "bytes"])
 
@@ -205,8 +205,6 @@ internal final class NetworkRequest: RequestWithDefaultCallbacks, CustomDebugStr
 
         if shouldIgnoreResponse(newInfo.response)
             { return }
-
-        debugLog(.networkDetails, ["Response after transformer pipeline:", newInfo.isNew ? " (new data)" : " (data unchanged)", newInfo.response.dump()])
 
         progressTracker.complete()
 

--- a/Source/Siesta/Request/RequestCallbacks.swift
+++ b/Source/Siesta/Request/RequestCallbacks.swift
@@ -36,7 +36,7 @@ extension RequestWithDefaultCallbacks
         {
         return addResponseCallback
             {
-            if case .success(let entity) = $0.response , $0.isNew
+            if $0.isNew, case .success(let entity) = $0.response
                 { callback(entity) }
             }
         }
@@ -45,7 +45,7 @@ extension RequestWithDefaultCallbacks
         {
         return addResponseCallback
             {
-            if case .success = $0.response , !$0.isNew
+            if !$0.isNew, case .success = $0.response
                 { callback() }
             }
         }

--- a/Source/Siesta/RequestError.swift
+++ b/Source/Siesta/RequestError.swift
@@ -134,6 +134,12 @@ public extension RequestError
         {
         // MARK: Request Errors
 
+        /// Resource’s URL is nil or syntactically invalid.
+        public struct InvalidURL: Error
+            {
+            public let urlSource: URLConvertible?
+            }
+
         /// Unable to create a text request with the requested character encoding.
         public struct UnencodableText: Error
             {

--- a/Source/Siesta/Resource/Resource.swift
+++ b/Source/Siesta/Resource/Resource.swift
@@ -646,7 +646,7 @@ public final class Resource: NSObject
             + urlDescription
             + ")["
             + (isLoading ? "L" : "")
-            + (latestData != nil ? "D" : "")
+            + (_latestData != nil ? "D" : "")
             + (latestError != nil ? "E" : "")
             + "]"
         }

--- a/Source/Siesta/Resource/Resource.swift
+++ b/Source/Siesta/Resource/Resource.swift
@@ -627,7 +627,7 @@ public final class Resource: NSObject
         configuration.pipeline.cachedEntity(for: self)
             {
             [weak self] entity in
-            guard let resource = self , resource.latestData == nil else
+            guard let resource = self, resource.latestData == nil else
                 {
                 debugLog(.cache, ["Ignoring cache hit for", self, " because it is either deallocated or already has data"])
                 return

--- a/Source/Siesta/Resource/Resource.swift
+++ b/Source/Siesta/Resource/Resource.swift
@@ -615,8 +615,8 @@ public final class Resource: NSObject
     /// :nodoc:
     public override var description: String
         {
-        return "Siesta.Resource("
-            + debugStr(url)
+        return "Resource("
+            + debugStr(url).replacePrefix(service.baseURL?.absoluteString ?? "\0", with: "…/")
             + ")["
             + (isLoading ? "L" : "")
             + (latestData != nil ? "D" : "")

--- a/Source/Siesta/Resource/Resource.swift
+++ b/Source/Siesta/Resource/Resource.swift
@@ -616,7 +616,7 @@ public final class Resource: NSObject
     public override var description: String
         {
         return "Resource("
-            + debugStr(url).replacePrefix(service.baseURL?.absoluteString ?? "\0", with: "…/")
+            + debugStr(url).replacingPrefix(service.baseURL?.absoluteString ?? "\0", with: "…/")
             + ")["
             + (isLoading ? "L" : "")
             + (latestData != nil ? "D" : "")

--- a/Source/Siesta/Resource/ResourceNavigation.swift
+++ b/Source/Siesta/Resource/ResourceNavigation.swift
@@ -93,10 +93,6 @@ extension Resource
         {
         return service.resource(absoluteURL:
             url.alterQuery
-                {
-                var params = $0
-                params[name] = value
-                return params
-                })
+                { $0[name] = value })
         }
     }

--- a/Source/Siesta/Resource/ResourceObserver.swift
+++ b/Source/Siesta/Resource/ResourceObserver.swift
@@ -220,10 +220,10 @@ public extension Resource
         {
         cleanDefunctObservers()
 
-        debugLog(.observers, [self, "sending", event, "to", observers.count, "observer" + (observers.count == 1 ? "" : "s")])
+        debugLog(.observers, [self, "sending", event, "event to", observers.count, "observer" + (observers.count == 1 ? "" : "s")])
         for entry in observers
             {
-            debugLog(.observers, [self, "sending", event, "to", entry.observer])
+            debugLog(.observers, ["  ↳", event, "→", entry.observer])
             entry.observer?.resourceChanged(self, event: event)
             }
         }

--- a/Source/Siesta/Resource/ResourceObserver.swift
+++ b/Source/Siesta/Resource/ResourceObserver.swift
@@ -190,9 +190,18 @@ public extension Resource
               detect duplicates. It is thus the caller’s responsibility to prevent redundant calls to this method.
     */
     @discardableResult
-    public func addObserver(owner: AnyObject, closure: @escaping ResourceObserverClosure) -> Self
+    public func addObserver(
+            owner: AnyObject,
+            file: String = #file,
+            line: Int = #line,
+            closure: @escaping ResourceObserverClosure)
+        -> Self
         {
-        return addObserver(ClosureObserver(closure: closure), owner: owner)
+        return addObserver(
+            ClosureObserver(
+                closure: closure,
+                debugDescription: "ClosureObserver(\(conciseSourceLocation(file: file, line: line)))"),
+            owner: owner)
         }
 
     /**
@@ -330,9 +339,10 @@ internal struct ObserverEntry: CustomStringConvertible
         }
     }
 
-private struct ClosureObserver: ResourceObserver
+private struct ClosureObserver: ResourceObserver, CustomDebugStringConvertible
     {
-    fileprivate let closure: ResourceObserverClosure
+    let closure: ResourceObserverClosure
+    let debugDescription: String
 
     func resourceChanged(_ resource: Resource, event: ResourceEvent)
         {

--- a/Source/Siesta/Service.swift
+++ b/Source/Siesta/Service.swift
@@ -119,8 +119,6 @@ open class Service: NSObject
             customBaseURL?.url?.appendingPathComponent(path.stripPrefix("/")))
         }
 
-    private static let invalidURL = URL(string: "null:")!     // URL we use when given bad URL for a resource
-
     /**
       Returns the unique resource with the given URL, ignoring `baseURL`.
 
@@ -138,8 +136,9 @@ open class Service: NSObject
 
         guard let url = urlConvertible?.url else
             {
-            debugLog(.network, ["WARNING: Invalid URL:", urlConvertible, "(all requests for this resource will fail)"])
-            return resource(absoluteURL: Service.invalidURL)
+            if let urlConvertible = urlConvertible
+                { debugLog(.network, ["WARNING: Invalid URL:", urlConvertible, "(all requests for this resource will fail)"]) }
+            return Resource(service: self, invalidURLSource: urlConvertible)
             }
 
         return resourceCache.get(url.absoluteString)

--- a/Source/Siesta/Service.swift
+++ b/Source/Siesta/Service.swift
@@ -59,10 +59,8 @@ open class Service: NSObject
             {
             self.baseURL = baseURL.alterPath
                 {
-                path in
-                !path.hasSuffix("/")
-                    ? path + "/"
-                    : path
+                if !$0.hasSuffix("/")
+                   { $0 += "/" }
                 }
             }
         else

--- a/Source/Siesta/Service.swift
+++ b/Source/Siesta/Service.swift
@@ -355,15 +355,17 @@ open class Service: NSObject
     internal func configuration(forResource resource: Resource, requestMethod: RequestMethod) -> Configuration
         {
         anyConfigSinceLastInvalidation = true
-        debugLog(.configuration, ["Computing configuration for", requestMethod, resource])
+        debugLog(.configuration, ["Computing configuration for", requestMethod.rawValue.uppercased(), resource])
         var config = Configuration()
         for entry in configurationEntries
             where entry.requestMethods.contains(requestMethod)
                && entry.configurationPattern(resource.url)
             {
-            debugLog(.configuration, ["Applying", entry, "to", resource])
+            debugLog(.configuration, ["  ├╴Applying", entry])
             entry.configurer(&config)
             }
+        debugLog(.configuration, ["  └╴Resulting configuration", config.dump("      ")])
+
         return config
         }
 

--- a/Source/Siesta/Support/DebugFormatting.swift
+++ b/Source/Siesta/Support/DebugFormatting.swift
@@ -17,7 +17,7 @@ internal func debugStr(
     -> String
     {
     guard let x = x else
-        { return "–" }
+        { return "nil" }
 
     var s: String
     if let debugPrintable = x as? CustomDebugStringConvertible

--- a/Source/Siesta/Support/DebugFormatting.swift
+++ b/Source/Siesta/Support/DebugFormatting.swift
@@ -50,6 +50,11 @@ internal func debugStr(
         .joined(separator: " ")
     }
 
+internal func conciseSourceLocation(file: String, line: Int) -> String
+    {
+    return "\((file as NSString).lastPathComponent):\(line)"
+    }
+
 internal func dumpHeaders(_ headers: [String:String], indent: String = "") -> String
     {
     var result = "\n" + indent + "headers (\(headers.count))"
@@ -86,7 +91,7 @@ extension Pipeline
             if stage.transformers.isEmpty
                 { result += " (no transformers)" }
             for transformer in stage.transformers
-                { result += "\n" + indent + "║⃘   " + debugStr(transformer) }
+                { result += "\n" + indent + "╟   " + debugStr(transformer) }
             if let cacheBox = stage.cacheBox
                 { result += "\n" + indent + "╟─→ " + cacheBox.description }
             }

--- a/Source/Siesta/Support/DebugFormatting.swift
+++ b/Source/Siesta/Support/DebugFormatting.swift
@@ -28,7 +28,7 @@ internal func debugStr(
     if consolidateWhitespace
         { s = s.replacingRegex(whitespacePat, " ") }
 
-    if let truncate = truncate , s.characters.count > truncate
+    if let truncate = truncate, s.characters.count > truncate
         { s = s.substring(to: s.index(s.startIndex, offsetBy: truncate)) + "…" }
 
     return s

--- a/Source/Siesta/Support/DebugFormatting.swift
+++ b/Source/Siesta/Support/DebugFormatting.swift
@@ -52,12 +52,46 @@ internal func debugStr(
 
 internal func dumpHeaders(_ headers: [String:String], indent: String = "") -> String
     {
-    var result = "\n" + indent + "headers: (\(headers.count))"
+    var result = "\n" + indent + "headers (\(headers.count))"
 
     for (k,v) in headers
         { result += "\n" + indent + "  \(k): \(v)" }
 
     return result
+    }
+
+extension Configuration
+    {
+    internal func dump(_ indent: String = "") -> String
+        {
+        return "\n" + indent + "expirationTime:            \(expirationTime) sec"
+             + "\n" + indent + "retryTime:                 \(retryTime) sec"
+             + "\n" + indent + "progressReportingInterval: \(progressReportingInterval) sec"
+             + dumpHeaders(headers, indent: indent)
+             + "\n" + indent + "requestDecorators: \(requestDecorators.count)"
+             + "\n" + indent + "pipeline"
+             + pipeline.dump(indent + "  ")
+        }
+    }
+
+extension Pipeline
+    {
+    internal func dump(_ indent: String = "") -> String
+        {
+        var result = ""
+        for stageKey in order
+            {
+            result += "\n" + indent + "║ " + stageKey.description + " stage"
+            let stage = self[stageKey]
+            if stage.transformers.isEmpty
+                { result += " (no transformers)" }
+            for transformer in stage.transformers
+                { result += "\n" + indent + "║⃘   " + debugStr(transformer) }
+            if let cacheBox = stage.cacheBox
+                { result += "\n" + indent + "╟─→ " + cacheBox.description }
+            }
+        return result
+        }
     }
 
 extension Response
@@ -76,13 +110,11 @@ extension Entity
     {
     internal func dump(_ indent: String = "") -> String
         {
-        var result =
-            "\n" + indent + "contentType: \(contentType)" +
-            "\n" + indent + "charset:     \(debugStr(charset))" +
-            dumpHeaders(headers, indent: indent) +
-            "\n" + indent + "content: (\(type(of: content)))\n"
-        result += formattedContent.replacingRegex("^|\n", "$0  " + indent)
-        return result
+        return "\n" + indent + "contentType: \(contentType)"
+             + "\n" + indent + "charset:     \(debugStr(charset))"
+             + dumpHeaders(headers, indent: indent)
+             + "\n" + indent + "content: (\(type(of: content)))\n"
+             + formattedContent.replacingRegex("^|\n", "$0  " + indent)
         }
 
     private var formattedContent: String

--- a/Source/Siesta/Support/DebugFormatting.swift
+++ b/Source/Siesta/Support/DebugFormatting.swift
@@ -112,11 +112,13 @@ extension Response
 
     internal func summary() -> String
         {
+        let kind: String, payload: String
         switch self
             {
-            case .success(let entity): return "success(\(type(of: entity.content)))"
-            case .failure(let error):  return "failure(\(type(of: error)))"
+            case .success(let entity): (kind, payload) = ("success", debugStr(entity.content, consolidateWhitespace: true, truncate: 80))
+            case .failure(let error):  (kind, payload) = ("failure", error.summary())
             }
+        return kind + ": " + payload
         }
     }
 
@@ -156,6 +158,18 @@ extension RequestError
             { result += "\n" + indent + "cause:          \(debugStr(cause, consolidateWhitespace: true))" }
         if let entity = entity
             { result += "\n" + indent + "entity:" + entity.dump(indent + "  ") }
+        return result
+        }
+
+    internal func summary() -> String
+        {
+        var result = debugStr(userMessage, truncate: 24)
+        if let httpStatusCode = httpStatusCode
+            { result += " \(httpStatusCode)" }
+        if let content = entity?.content
+            { result += " content: \(type(of: content))" }
+        if let cause = cause
+            { result += " cause: " + debugStr(cause, truncate: 32)}
         return result
         }
     }

--- a/Source/Siesta/Support/DebugFormatting.swift
+++ b/Source/Siesta/Support/DebugFormatting.swift
@@ -104,6 +104,15 @@ extension Response
             case .failure(let value): return "\n" + indent + "failure" + value.dump(indent + "  ")
             }
         }
+
+    internal func summary() -> String
+        {
+        switch self
+            {
+            case .success(let entity): return "success(\(type(of: entity.content)))"
+            case .failure(let error):  return "failure(\(type(of: error)))"
+            }
+        }
     }
 
 extension Entity

--- a/Source/Siesta/Support/Logging.swift
+++ b/Source/Siesta/Support/Logging.swift
@@ -55,8 +55,16 @@ public enum LogCategory: String
 /// The set of categories to log. Can be changed at runtime.
 public var enabledLogCategories = Set<LogCategory>()
 
+private let maxCategoryNameLength = LogCategory.all.map { Int($0.rawValue.characters.count) }.max() ?? 0
+
 /// Inject your custom logger to do something other than print to stdout.
-public var logger: (LogCategory, String) -> Void = { print("[Siesta:\($0.rawValue)] \($1)") }
+public var logger: (LogCategory, String) -> Void =
+    {
+    let paddedCategory = $0.rawValue.padding(toLength: maxCategoryNameLength, withPad: " ", startingAt: 0)
+    let prefix = "Siesta:\(paddedCategory)│ "
+    let indentedMessage = $1.replacingOccurrences(of: "\n", with: "\n" + prefix)
+    print(prefix + indentedMessage)
+    }
 
 internal func debugLog(_ category: LogCategory, _ messageParts: @autoclosure () -> [Any?])
     {

--- a/Source/Siesta/Support/Logging.swift
+++ b/Source/Siesta/Support/Logging.swift
@@ -22,7 +22,7 @@ public enum LogCategory: String
     case networkDetails
 
     /// Details of how the `ResponseTransformer` parses responses.
-    case responseProcessing
+    case pipeline
 
     /// `ResourceEvent` broadcast by resources.
     case stateChanges
@@ -49,7 +49,7 @@ public enum LogCategory: String
     public static let detailed = Set<LogCategory>(all.filter { $0 != networkDetails})
 
     /// The whole schebang!
-    public static let all: Set<LogCategory> = [network, networkDetails, responseProcessing, stateChanges, observers, staleness, cache, configuration]
+    public static let all: Set<LogCategory> = [network, networkDetails, pipeline, stateChanges, observers, staleness, cache, configuration]
     }
 
 /// The set of categories to log. Can be changed at runtime.

--- a/Source/Siesta/Support/Logging.swift
+++ b/Source/Siesta/Support/Logging.swift
@@ -13,7 +13,7 @@ import Foundation
 
     - SeeAlso: [Logging Guide](https://github.com/bustoutsolutions/siesta/blob/master/Docs/logging.md)
 */
-public enum LogCategory: String
+public enum LogCategory
     {
     /// Summary of network requests: HTTP method, URL, and result code.
     case network
@@ -55,12 +55,12 @@ public enum LogCategory: String
 /// The set of categories to log. Can be changed at runtime.
 public var enabledLogCategories = Set<LogCategory>()
 
-private let maxCategoryNameLength = LogCategory.all.map { Int($0.rawValue.characters.count) }.max() ?? 0
+private let maxCategoryNameLength = LogCategory.all.map { Int(String(describing: $0).characters.count) }.max() ?? 0
 
 /// Inject your custom logger to do something other than print to stdout.
 public var logger: (LogCategory, String) -> Void =
     {
-    let paddedCategory = $0.rawValue.padding(toLength: maxCategoryNameLength, withPad: " ", startingAt: 0)
+    let paddedCategory = String(describing: $0).padding(toLength: maxCategoryNameLength, withPad: " ", startingAt: 0)
     var threadName = ""
     if !Thread.isMainThread
         {

--- a/Source/Siesta/Support/Logging.swift
+++ b/Source/Siesta/Support/Logging.swift
@@ -50,10 +50,10 @@ public enum LogCategory
 
     /// The whole schebang!
     public static let all: Set<LogCategory> = [network, networkDetails, pipeline, stateChanges, observers, staleness, cache, configuration]
-    }
 
-/// The set of categories to log. Can be changed at runtime.
-public var enabledLogCategories = Set<LogCategory>()
+    /// The set of categories to log. Can be changed at runtime.
+    public static var enabled = Set<LogCategory>()
+    }
 
 private let maxCategoryNameLength = LogCategory.all.map { Int(String(describing: $0).characters.count) }.max() ?? 0
 
@@ -80,6 +80,6 @@ public var logger: (LogCategory, String) -> Void =
 
 internal func debugLog(_ category: LogCategory, _ messageParts: @autoclosure () -> [Any?])
     {
-    if enabledLogCategories.contains(category)
+    if LogCategory.enabled.contains(category)
         { logger(category, debugStr(messageParts())) }
     }

--- a/Source/Siesta/Support/Logging.swift
+++ b/Source/Siesta/Support/Logging.swift
@@ -61,7 +61,10 @@ private let maxCategoryNameLength = LogCategory.all.map { Int($0.rawValue.charac
 public var logger: (LogCategory, String) -> Void =
     {
     let paddedCategory = $0.rawValue.padding(toLength: maxCategoryNameLength, withPad: " ", startingAt: 0)
-    let prefix = "Siesta:\(paddedCategory)│ "
+    let threadName = Thread.isMainThread
+        ? "main  "
+        : String(format: "BG-%03x", ObjectIdentifier(Thread.current).hashValue >> 4 & 0xFFF)
+    let prefix = "\(threadName) Siesta:\(paddedCategory) │ "
     let indentedMessage = $1.replacingOccurrences(of: "\n", with: "\n" + prefix)
     print(prefix + indentedMessage)
     }

--- a/Source/Siesta/Support/Logging.swift
+++ b/Source/Siesta/Support/Logging.swift
@@ -61,10 +61,19 @@ private let maxCategoryNameLength = LogCategory.all.map { Int($0.rawValue.charac
 public var logger: (LogCategory, String) -> Void =
     {
     let paddedCategory = $0.rawValue.padding(toLength: maxCategoryNameLength, withPad: " ", startingAt: 0)
-    let threadName = Thread.isMainThread
-        ? "main  "
-        : String(format: "BG-%03x", ObjectIdentifier(Thread.current).hashValue >> 4 & 0xFFF)
-    let prefix = "\(threadName) Siesta:\(paddedCategory) │ "
+    var threadName = ""
+    if !Thread.isMainThread
+        {
+        threadName += "[thread "
+        var threadID = abs(ObjectIdentifier(Thread.current).hashValue &* 524287)
+        for _ in 0..<4
+            {
+            threadName.append(Character(UnicodeScalar(threadID % 0x55 + 0x13a0)!))
+            threadID /= 0x55
+            }
+        threadName += "]"
+        }
+    let prefix = "Siesta:\(paddedCategory) │ \(threadName)"
     let indentedMessage = $1.replacingOccurrences(of: "\n", with: "\n" + prefix)
     print(prefix + indentedMessage)
     }

--- a/Source/Siesta/Support/NSURL+Siesta.swift
+++ b/Source/Siesta/Support/NSURL+Siesta.swift
@@ -31,18 +31,17 @@ extension URL: URLConvertible
 
 internal extension URL
     {
-    func alterPath(_ pathMutator: (String) -> String) -> URL?
+    func alterPath(_ pathMutator: (inout String) -> Void) -> URL?
         {
         guard var components = URLComponents(url: self, resolvingAgainstBaseURL: true) else
             { return nil }
 
-        // TODO: used to be a nil check here?
-        components.path = pathMutator(components.path)
+        pathMutator(&components.path)
 
         return components.url
         }
 
-    func alterQuery(_ queryMutator: ([String:String?]) -> [String:String?]) -> URL?
+    func alterQuery(_ queryMutator: (inout [String:String?]) -> Void) -> URL?
         {
         guard var components = URLComponents(url: self, resolvingAgainstBaseURL: true) else
             { return nil }
@@ -52,7 +51,9 @@ internal extension URL
         for item in queryItems
             { queryDict[item.name] = item.value }
 
-        let newItems = queryMutator(queryDict)
+        queryMutator(&queryDict)
+
+        let newItems = queryDict
             .sorted { $0.0 < $1.0 }   // canonicalize order to help resource URLs be unique
             .filter { $1 != nil }
             .map { URLQueryItem(name: $0.0, value: $0.1?.nilIfEmpty) }

--- a/Source/Siesta/Support/String+Siesta.swift
+++ b/Source/Siesta/Support/String+Siesta.swift
@@ -17,6 +17,13 @@ internal extension String
             : self
         }
 
+    func replacingPrefix(_ prefix: String, with replacement: String) -> String
+        {
+        return hasPrefix(prefix)
+            ? replacement + stripPrefix(prefix)
+            : self
+        }
+
     var capitalizedFirstCharacter: String
         {
         guard !self.isEmpty else

--- a/Source/Siesta/Support/Ω_Deprecations.swift
+++ b/Source/Siesta/Support/Ω_Deprecations.swift
@@ -9,6 +9,14 @@
 
 import Foundation
 
+// MARK: Deprecated in 1.0-rc.1
+
+extension LogCategory
+    {
+    @available(*, deprecated: 0.99, renamed: "pipeline")
+    public static let responseProcessing = LogCategory.pipeline
+    }
+
 // MARK: Swift 3 deprecations
 
 extension Configuration
@@ -96,8 +104,8 @@ extension LogCategory
     @available(*, deprecated: 0.99, renamed: "networkDetails")
     public static let NetworkDetails = LogCategory.networkDetails
 
-    @available(*, deprecated: 0.99, renamed: "responseProcessing")
-    public static let ResponseProcessing = LogCategory.responseProcessing
+    @available(*, deprecated: 0.99, renamed: "pipeline")
+    public static let ResponseProcessing = LogCategory.pipeline
 
     @available(*, deprecated: 0.99, renamed: "stateChanges")
     public static let StateChanges = LogCategory.stateChanges

--- a/Source/Siesta/Support/Ω_Deprecations.swift
+++ b/Source/Siesta/Support/Ω_Deprecations.swift
@@ -17,6 +17,13 @@ extension LogCategory
     public static let responseProcessing = LogCategory.pipeline
     }
 
+@available(*, deprecated: 0.99, renamed: "LogCategory.enabled")
+public var enabledLogCategories: Set<LogCategory>
+    {
+    get { return LogCategory.enabled }
+    set { LogCategory.enabled = newValue }
+    }
+
 // MARK: Swift 3 deprecations
 
 extension Configuration

--- a/Tests/ServiceSpec.swift
+++ b/Tests/ServiceSpec.swift
@@ -66,11 +66,6 @@ class ServiceSpec: SiestaSpec
                         expectInvalidResource(bareService().resource("foo"))
                         }
 
-                    it("fails all requests for relative URLs")
-                        {
-                        expectInvalidResource(bareService().resource(absoluteURL: "/foo"))
-                        }
-
                     it("allows requests for absolute URLs")
                         {
                         let resource = bareService().resource(absoluteURL: "http://foo.bar")
@@ -517,5 +512,5 @@ func checkPathExpansion(_ baseURL: String, path resourcePath: String, expect exp
 
 func expectInvalidResource(_ resource: Resource)
     {
-    awaitFailure(resource.load())
+    awaitFailure(resource.load(), alreadyCompleted: true)
     }

--- a/Tests/SiestaSpec.swift
+++ b/Tests/SiestaSpec.swift
@@ -18,7 +18,7 @@ class SiestaSpec: QuickSpec
         {
         beforeSuite
             {
-            Siesta.enabledLogCategories = LogCategory.all
+            Siesta.LogCategory.enabled = LogCategory.all
             Siesta.logger = { currentLogMessages.append($1) }
             }
 


### PR DESCRIPTION
Here are improvements to Siesta’s log output, aimed at making the output clearer, more self-explanatory, and more focused on common points of error and confusion.

<img width="1434" alt="siesta-logging" src="https://cloud.githubusercontent.com/assets/378162/18883113/9d3912da-84a7-11e6-9729-f59a4de4fcb8.png">

Full output: [**Before**](https://gist.github.com/pcantrell/30cf2ddc69df7af729670e15fc8e5b89) | [**After**](https://gist.github.com/pcantrell/90a2e3b41f7b277f157c18a7a7348c69)

There are still two shortcomings of the logging:

- The pipeline logs some transformations that didn’t actually have any effect. This makes the pipeline logging just a bit hard to follow. A better solution would check each transformer’s output for changes, but there is no way in Swift to check arbitrary entity content for equality.
- Pipelines work on background queues. When two are processing responses simultaneously, their logs can become intermingled, which is quite hard to read. The current logging solves this by prefixing backgrounded lines with a synthetic thread ID (using the [Cherokee syllabary](https://en.wikipedia.org/wiki/Cherokee_syllabary) because it is amazing, the story behind it is amazing, and Sequoyah was a freakin’ genius). This lets a reader disentangle the mingled lines, but it’s not ideal.

This PR also renames the `responseProcessing` log category to `pipeline`.