### PR TITLE
Fixes for stoppedObserving(resource:) and Obj-C observer ownership

### DIFF
--- a/Source/Siesta/Resource/Resource.swift
+++ b/Source/Siesta/Resource/Resource.swift
@@ -39,6 +39,7 @@ public final class Resource: NSObject
     private let permanentFailure: RequestError?
 
     internal var observers = [AnyHashable:ObserverEntry]()
+    internal var defunctObserverCheckScheduled = false
     internal var defunctObserverCheckCounter = 0
 
 
@@ -651,12 +652,6 @@ public final class Resource: NSObject
             + (latestError != nil ? "E" : "")
             + "]"
         }
-    }
-
-extension Resource: WeakCacheValue
-    {
-    func allowRemovalFromCache()
-        { cleanDefunctObservers() }
     }
 
 /// Dictionaries and arrays can both be passed to `Resource.request(_:json:contentType:requestMutation:)`.

--- a/Source/Siesta/Resource/ResourceObserver.swift
+++ b/Source/Siesta/Resource/ResourceObserver.swift
@@ -369,7 +369,7 @@ internal class ObserverEntry: CustomStringConvertible
         if let observer = observer
             { return debugStr(observer) }
         else
-            { return "<deallocated: \(originalObserverDescription)>" }
+            { return "<deallocated: \(originalObserverDescription ?? "–")>" }
         }
     }
 

--- a/Source/Siesta/Resource/ResourceObserver.swift
+++ b/Source/Siesta/Resource/ResourceObserver.swift
@@ -286,15 +286,7 @@ public extension Resource
         for observer in observers.values
             { observer.cleanUp() }
 
-        let removed = observers.removeValues { $0.isDefunct }
-
-        for entry in removed
-            {
-            debugLog(.observers, [self, "removing observer whose owners are all gone:", entry])
-            entry.observer?.stoppedObserving(resource: self)
-            }
-
-        if !removed.isEmpty
+        if observers.removeValues(matching: { $0.isDefunct })
             { observersChanged() }
         }
     }
@@ -319,6 +311,12 @@ internal class ObserverEntry: CustomStringConvertible
         self.resource = resource
         if LogCategory.enabled.contains(.observers)
             { originalObserverDescription = debugStr(observer) }  // So we know what was deallocated if it gets logged
+        }
+
+    deinit
+        {
+        debugLog(.observers, [self, "removing observer whose owners are all gone:", self])
+        observer?.stoppedObserving(resource: resource)
         }
 
     func addOwner(_ owner: AnyObject)

--- a/Source/Siesta/Support/Collection+Siesta.swift
+++ b/Source/Siesta/Support/Collection+Siesta.swift
@@ -84,18 +84,18 @@ internal extension Dictionary
             }()
         }
 
-    mutating func removeValues(matching predicate: (Value) -> Bool) -> [Value]
+    mutating func removeValues(matching predicate: (Value) -> Bool) -> Bool
         {
-        var removed = [Value]()
+        var anyRemoved = false
         for (key, value) in self
             {
             if predicate(value)
                 {
                 removeValue(forKey: key)
-                removed.append(value)
+                anyRemoved = true
                 }
             }
-        return removed
+        return anyRemoved
         }
     }
 

--- a/Source/Siesta/Support/Siesta-ObjC.swift
+++ b/Source/Siesta/Support/Siesta-ObjC.swift
@@ -244,21 +244,30 @@ public protocol _objc_ResourceObserver
 
 private class _objc_ResourceObserverGlue: ResourceObserver, CustomDebugStringConvertible
     {
+    var resource: Resource?
     var objcObserver: _objc_ResourceObserver
-    var observerIdentity: AnyHashable
-        { return ObjectIdentifier(objcObserver) }
 
     init(objcObserver: _objc_ResourceObserver)
         { self.objcObserver = objcObserver }
 
+    deinit
+        {
+        if let resource = resource
+            { objcObserver.stoppedObservingResource?(resource) }
+        }
+
     func resourceChanged(_ resource: Resource, event: ResourceEvent)
-        { objcObserver.resourceChanged(resource, event: event._objc_stringForm) }
+        {
+        if case .observerAdded = event
+            { self.resource = resource }
+        objcObserver.resourceChanged(resource, event: event._objc_stringForm)
+        }
 
     func resourceRequestProgress(_ resource: Resource, progress: Double)
         { objcObserver.resourceRequestProgress?(resource, progress: progress) }
 
-    func stoppedObservingResource(_ resource: Resource)
-        { objcObserver.stoppedObservingResource?(resource) }
+    var observerIdentity: AnyHashable
+        { return ObjectIdentifier(objcObserver) }
 
     var debugDescription: String
         { return debugStr(objcObserver) }

--- a/Source/Siesta/Support/Siesta-ObjC.swift
+++ b/Source/Siesta/Support/Siesta-ObjC.swift
@@ -244,34 +244,24 @@ public protocol _objc_ResourceObserver
 
 private class _objc_ResourceObserverGlue: ResourceObserver, CustomDebugStringConvertible
     {
-    weak var objcObserver: _objc_ResourceObserver?
+    var objcObserver: _objc_ResourceObserver
     var observerIdentity: AnyHashable
-        {
-        if let wrapped = objcObserver
-            { return ObjectIdentifier(wrapped) }
-        else
-            { return UniqueObserverIdentity() }
-        }
+        { return ObjectIdentifier(objcObserver) }
 
     init(objcObserver: _objc_ResourceObserver)
         { self.objcObserver = objcObserver }
 
     func resourceChanged(_ resource: Resource, event: ResourceEvent)
-        { objcObserver?.resourceChanged(resource, event: event._objc_stringForm) }
+        { objcObserver.resourceChanged(resource, event: event._objc_stringForm) }
 
     func resourceRequestProgress(_ resource: Resource, progress: Double)
-        { objcObserver?.resourceRequestProgress?(resource, progress: progress) }
+        { objcObserver.resourceRequestProgress?(resource, progress: progress) }
 
     func stoppedObservingResource(_ resource: Resource)
-        { objcObserver?.stoppedObservingResource?(resource) }
+        { objcObserver.stoppedObservingResource?(resource) }
 
     var debugDescription: String
-        {
-        if objcObserver != nil
-            { return debugStr(objcObserver) }
-        else
-            { return "_objc_ResourceObserverGlue<deallocated delegate>" }
-        }
+        { return debugStr(objcObserver) }
     }
 
 extension ResourceEvent

--- a/Tests/Functional/ObjcCompatibilitySpec.m
+++ b/Tests/Functional/ObjcCompatibilitySpec.m
@@ -195,6 +195,11 @@
         expect(observer0.eventsReceived).to(equal(@[@"ObserverAdded", @"Requested", @"NewData(Network)"]));
         expect(observer1.eventsReceived).to(equal(@[@"ObserverAdded", @"Requested", @"NewData(Network)"]));
         expect(@(blockObserverCalls)).to(equal(@3));
+
+        [resource removeObserversOwnedBy:observer1];
+        [resource wipe];  // forces observer cleanup
+        expect(observer0.eventsReceived).to(equal(@[@"ObserverAdded", @"Requested", @"NewData(Network)", @"NewData(Wipe)"]));
+        expect(observer1.eventsReceived).to(equal(@[@"ObserverAdded", @"Requested", @"NewData(Network)", @"stoppedObserving"]));
         });
 
     it(@"honors observer ownership", ^
@@ -236,6 +241,11 @@
     if(!self.eventsReceived)
         self.eventsReceived = [NSMutableArray array];
     [self.eventsReceived addObject:event];
+    }
+
+- (void) stoppedObservingResource: (BOSResource * _Nonnull) resource
+    {
+    [self.eventsReceived addObject:@"stoppedObserving"];
     }
 
 @end

--- a/Tests/Functional/ObjcCompatibilitySpec.m
+++ b/Tests/Functional/ObjcCompatibilitySpec.m
@@ -197,9 +197,32 @@
         expect(@(blockObserverCalls)).to(equal(@3));
         });
 
-    // TODO: BOSResourceObserver
+    it(@"honors observer ownership", ^
+        {
+        // Keep events array even after observer deallocated
+        NSMutableArray *eventsReceived = [NSMutableArray array];
+        ObjcObserver *observer = [[ObjcObserver alloc] init];
+        observer.eventsReceived = eventsReceived;
 
-    // TODO: BOSResourceStatusOverlay
+        // Let Siesta ownership control observer lifecycle
+        NSObject *owner = [[NSObject alloc] init];
+        [resource addObserver:observer owner:owner];
+        ObjcObserver __weak *observerWeak = observer;
+        observer = nil;
+
+        // Owner still around: we get events, observer lives on
+        [resource wipe];
+        expect(observerWeak).notTo(beNil());
+        expect(eventsReceived).to(equal(@[@"ObserverAdded", @"NewData(Wipe)"]));
+
+        // Owner still around: no more events, observer gone
+        owner = nil;
+        [resource wipe];
+        expect(observerWeak).to(beNil());
+        expect(eventsReceived).to(equal(@[@"ObserverAdded", @"NewData(Wipe)"]));
+        });
+
+    // TODO: more BOSResourceObserver
     }
 
 @end

--- a/Tests/Functional/ResourceObserversSpec.swift
+++ b/Tests/Functional/ResourceObserversSpec.swift
@@ -39,9 +39,9 @@ class ResourceObserversSpec: ResourceSpecBase
                 resource().addObserver(observer2)
 
                 resource().removeObservers(ownedBy: observer())
-                forceObserverCleanup(for: resource())
+                awaitObserverCleanup(for: resource())
                 expect(observer().stoppedObservingCalled) == true
-                expect(observer2.stoppedObservingCalled ) == false
+                expect(observer2.stoppedObservingCalled)  == false
                 }
 
             it("receives a notification every time it is removed and re-added")
@@ -243,7 +243,7 @@ class ResourceObserversSpec: ResourceSpecBase
                         observer().expect(.requested)
                         observer().expect(.newData(.network))
                         }
-                    forceObserverCleanup(for: resource())
+                    awaitObserverCleanup(for: resource())
                     expect(observer().stoppedObservingCalled) == !stillObserving
                     awaitNewData(resource().load())
                     }
@@ -290,14 +290,14 @@ class ResourceObserversSpec: ResourceSpecBase
 
             func expectResourceToBeRetained()
                 {
-                forceObserverCleanup(for: resourceWeak)
+                awaitObserverCleanup(for: resourceWeak)
                 simulateMemoryWarning()
                 expect(resourceWeak).notTo(beNil())
                 }
 
             func expectResourceNotToBeRetained()
                 {
-                forceObserverCleanup(for: resourceWeak)
+                awaitObserverCleanup(for: resourceWeak)
                 simulateMemoryWarning()
                 expect(resourceWeak).to(beNil())
                 }

--- a/Tests/Functional/ResourceObserversSpec.swift
+++ b/Tests/Functional/ResourceObserversSpec.swift
@@ -58,7 +58,7 @@ class ResourceObserversSpec: ResourceSpecBase
             it("is unaffected by removeObservers() with nil owner")
                 {
                 resource().removeObservers(ownedBy: nil)
-                expect(observer().stoppedObservingCalled ) == false
+                expect(observer().stoppedObservingCalled) == false
                 }
 
             it("is chainable")
@@ -243,6 +243,8 @@ class ResourceObserversSpec: ResourceSpecBase
                         observer().expect(.requested)
                         observer().expect(.newData(.network))
                         }
+                    forceObserverCleanup(for: resource())
+                    expect(observer().stoppedObservingCalled) == !stillObserving
                     awaitNewData(resource().load())
                     }
 

--- a/Tests/Functional/ResourceSpecBase.swift
+++ b/Tests/Functional/ResourceSpecBase.swift
@@ -184,10 +184,17 @@ func setResourceTime(_ time: TimeInterval)
     fakeNow = time
     }
 
-// Checks for removed observers normally get batched up. This forces one now
-// so we can make assertions about who’s left observing and who isn’t.
-func forceObserverCleanup(for resource: Resource?)
+// Checks for removed observers normally get batched up and run later after a delay.
+// This call waits for that to finish so we can check who’s left observing and who isn’t.
+//
+// Since there’s no way to directly detect the cleanup, and thus no positive indicator to
+// wait for, we just wait for all tasks currently queued on the main thread to complete.
+
+func awaitObserverCleanup(for resource: Resource?)
     {
-    resource?.cleanDefunctObservers(force: true)
+    let cleanupExpectation = QuickSpec.current().expectation(description: "awaitObserverCleanup")
+    DispatchQueue.main.async
+        { cleanupExpectation.fulfill() }
+    QuickSpec.current().waitForExpectations(timeout: 1, handler: nil)
     }
 


### PR DESCRIPTION
Several related improvements:

- Fixed a “what was I thinking?” bug which would cause Objective-C observers to be prematurely deallocated if they were not retained outside of Siesta.
- Fixed an issue that caused Obj-C observers to sometimes not receive `[BOSResourceObserver stoppedObservingResource:]`
- Optimizations in #117 caused an indefinite delay in observers receiving `stoppedObserving(…)` under certain circumstances. This patch leaves those optimizations in place, but ensures that cleanup happens within a bounded time.