### PR TITLE
Workaround for Swift bug taking type(of:) existentials 

### DIFF
--- a/Source/Siesta/Support/ARC+Siesta.swift
+++ b/Source/Siesta/Support/ARC+Siesta.swift
@@ -39,9 +39,12 @@ internal struct StrongOrWeakRef<T>
     init(_ value: T)
         {
         strongRef = value
-        weakRef = isObject(value)
-            ? value as AnyObject?
-            : nil
+        weakRef = value as AnyObject
+        // More performant version of previous line, once
+        // https://bugs.swift.org/browse/SR-2867 is fixed:
+//        weakRef = isObject(value)
+//            ? value as AnyObject?
+//            : nil
         }
 
     var strong: Bool


### PR DESCRIPTION
Workaround for this Swift bug: https://bugs.swift.org/browse/SR-2867

Incurs a ~30% performance hit in observer housekeeping.

Fixes #120.