### PR TITLE
Fixed: stoppedObserving incorrectly not called

### DIFF
--- a/Source/Siesta/Resource/ResourceObserver.swift
+++ b/Source/Siesta/Resource/ResourceObserver.swift
@@ -30,8 +30,22 @@ public protocol ResourceObserver
     func resourceRequestProgress(for resource: Resource, progress: Double)
 
     /**
-      Called when this observer stops observing a resource. Use for making `removeObservers(ownedBy:)` trigger
-      other cleanup.
+      Called when this observer stops observing a resource, if the observer itself still exists.
+      Use for making `removeObservers(ownedBy:)` trigger other cleanup.
+
+      - Warning: Only observers that are **retained outside of Siesta** will receive this message.
+          This method is **not** called if deallocation of the observer itself is what caused it to stop observing.
+
+          For example:
+
+              var myObserver = MyObserver()
+              resource.addObserver(myObserver)  // myObserver is self-owned, so...
+              myObserver = nil                  // this deallocates it, but...
+              // ...myObserver never receives stoppedObserving(resource:), because
+              // there is no way for Siesta to know that it should stop observing
+              // other than checking whether it is already deallocated.
+
+          In the situation above, `MyObserver` should implement any end-of-lifcycle cleanup using `deinit`.
     */
     func stoppedObserving(resource: Resource)
 

--- a/Source/Siesta/Resource/ResourceObserver.swift
+++ b/Source/Siesta/Resource/ResourceObserver.swift
@@ -348,7 +348,7 @@ internal class ObserverEntry: CustomStringConvertible
 
     deinit
         {
-        debugLog(.observers, [self, "removing observer whose owners are all gone:", self])
+        debugLog(.observers, ["removing observer of", resource, "whose owners are all gone:", self])
         observer?.stoppedObserving(resource: resource)
         }
 

--- a/Tests/Functional/ResourceObserversSpec.swift
+++ b/Tests/Functional/ResourceObserversSpec.swift
@@ -54,6 +54,32 @@ class ResourceObserversSpec: ResourceSpecBase
                 awaitObserverCleanup(for: resource())
                 }
 
+            it("receives removal notification if not externally retained but not self-owned")
+                {
+                var observer2: TestObserverWithExpectations? = TestObserverWithExpectations()
+                observer2?.expect(.observerAdded)
+                resource().addObserver(observer2!, owner: observer)  // not self-owned
+
+                observer.expectStoppedObserving()
+                observer2!.expectStoppedObserving()
+                observer2 = nil
+                resource().removeObservers(ownedBy: observer)
+                awaitObserverCleanup(for: resource())
+                }
+
+            it("does not receive removal notification if self-owned and not externally retained")
+                {
+                var observer2: TestObserverWithExpectations? = TestObserverWithExpectations()
+                observer2?.expect(.observerAdded)
+                resource().addObserver(observer2!)  // self-owned
+
+                observer.expectStoppedObserving()
+                // No expectStoppedObserving() for observer2!
+                observer2 = nil
+                resource().removeObservers(ownedBy: observer)
+                awaitObserverCleanup(for: resource())
+                }
+
             it("receives a notification every time it is removed and re-added")
                 {
                 let observer2 = TestObserverWithExpectations()


### PR DESCRIPTION
This normalizes the behavior of `ResourceObserver.stoppedObserving(resource:)`.

Previously, `stoppedObserving` would incorrectly not be called for … oh, let’s see if I can get this right: self-owned observers which were not externally retained, and which stopped observing due to a call to `removeObservers(ownedBy:)`.

After this fix, `stoppedObserving` is always called unless an observer is both self-owned _and_ removed because it was deallocated. (Siesta cannot call `stoppedObserving` in that situation. For an explanation,  see [the updated API docs](https://github.com/bustoutsolutions/siesta/blob/bcd4fb2459e5756c36453b57f7751ce0b8d52654/Source/Siesta/Resource/ResourceObserver.swift#L36-L47) in this patch.)

It’s a [one-line fix](https://github.com/bustoutsolutions/siesta/commit/0cd076fdacc981f70f2fa672530b9a038243ca26#diff-656c878a66aecc9279c4e103910bf769L390). The bulk of the changed code is a revamp of the observer tests to test `stoppedObserving` in all scenarios, along with the other observer events.