### PR TITLE
BOSEntity.content can now be non-nullable

### DIFF
--- a/Source/Siesta/Support/Siesta-ObjC.swift
+++ b/Source/Siesta/Support/Siesta-ObjC.swift
@@ -45,7 +45,7 @@ import Foundation
 @objc(BOSEntity)
 public class _objc_Entity: NSObject
     {
-    public var content: AnyObject?
+    public var content: AnyObject
     public var contentType: String
     public var charset: String?
     public var etag: String?
@@ -64,7 +64,7 @@ public class _objc_Entity: NSObject
 
     internal init(_ entity: Entity<Any>)
         {
-        self.content     = entity.content as AnyObject?
+        self.content     = entity.content as AnyObject
         self.contentType = entity.contentType
         self.charset     = entity.charset
         self.etag        = entity.etag


### PR DESCRIPTION
`Entity.content` is non-optional. However, in the Obj-C wrapper, `BOSEntity.content` was because there was no guarantee that the content was representable as an `NSObject`.

In Swift 3, this is now longer the case thanks to `_SwiftValue` magic. [This conversion](https://github.com/bustoutsolutions/siesta/blob/e54df18916a7c035a597affc132d89fe15074c15/Source/Siesta/Support/Siesta-ObjC.swift#L67) now works. This PR makes `BOSEntity.content` non-nullable: although it is not possible to actually _work_ with a Swift struct from Obj-C, the content is at least there.