### PR TITLE
Repeating a chained request repeats the wrapped request

### DIFF
--- a/Source/Siesta/Request/NetworkRequest.swift
+++ b/Source/Siesta/Request/NetworkRequest.swift
@@ -48,21 +48,21 @@ internal final class NetworkRequest: RequestWithDefaultCallbacks, CustomDebugStr
         progressTracker = ProgressTracker(isGet: underlyingRequest.httpMethod == "GET")
         }
 
-    func start()
+    func start() -> Self
         {
         DispatchQueue.mainThreadPrecondition()
 
         guard self.networking == nil else
             {
             debugLog(.networkDetails, [requestDescription, "already started"])
-            return
+            return self
             }
 
         guard !wasCancelled else
             {
             debugLog(.network, [requestDescription, "will not start because it was already cancelled"])
             underlyingNetworkRequestCompleted = true
-            return
+            return self
             }
 
         debugLog(.network, [requestDescription])
@@ -78,6 +78,8 @@ internal final class NetworkRequest: RequestWithDefaultCallbacks, CustomDebugStr
         progressTracker.start(
             networking,
             reportingInterval: config.progressReportingInterval)
+
+        return self
         }
 
     func cancel()

--- a/Source/Siesta/Request/Request.swift
+++ b/Source/Siesta/Request/Request.swift
@@ -94,7 +94,8 @@ public protocol Request: class
       - `Request.repeated()` does not automatically start the request it returns. This is to allow you to implement
         time-delayed retries.
     */
-    func start()
+    @discardableResult
+    func start() -> Self
 
     /**
       True if the request has received and handled a server response, encountered a pre-request client-side side error,

--- a/Source/Siesta/Request/RequestChaining.swift
+++ b/Source/Siesta/Request/RequestChaining.swift
@@ -139,7 +139,7 @@ internal final class RequestChain: RequestWithDefaultCallbacks
 
     func repeated() -> Request
         {
-        return RequestChain(wrapping: wrappedRequest, whenCompleted: determineAction)
+        return wrappedRequest.repeated().chained(whenCompleted: determineAction)
         }
 
     // MARK: Dummy implementaiton of progress (for now)

--- a/Source/Siesta/Request/RequestChaining.swift
+++ b/Source/Siesta/Request/RequestChaining.swift
@@ -119,9 +119,10 @@ internal final class RequestChain: RequestWithDefaultCallbacks
 
     typealias ActionCallback = (ResponseInfo) -> RequestChainAction
 
-    func start()
+    func start() -> Self
         {
         wrappedRequest.start()
+        return self
         }
 
     var isCompleted: Bool

--- a/Source/Siesta/Request/RequestCreation.swift
+++ b/Source/Siesta/Request/RequestCreation.swift
@@ -204,7 +204,8 @@ private final class FailedRequest: RequestWithDefaultCallbacks
         return self
         }
 
-    func start() { }
+    func start() -> Self
+        { return self }
 
     func cancel()
         { DispatchQueue.mainThreadPrecondition() }

--- a/Source/Siesta/Resource/Resource.swift
+++ b/Source/Siesta/Resource/Resource.swift
@@ -262,8 +262,7 @@ public final class Resource: NSObject
         // Track the fully decorated request
 
         trackRequest(req, using: &allRequests)
-        req.start()
-        return req
+        return req.start()
         }
 
     /**

--- a/Tests/Functional/RequestSpec.swift
+++ b/Tests/Functional/RequestSpec.swift
@@ -282,16 +282,14 @@ class RequestSpec: ResourceSpecBase
             it("sends a new network request on start()")
                 {
                 stubRepeatedRequest()
-                repeatedRequest().start()
-                awaitNewData(repeatedRequest())
+                awaitNewData(repeatedRequest().start())
                 }
 
             it("leaves the old request’s result intact")
                 {
                 _ = oldRequest()
                 stubRepeatedRequest("OK, maybe.")
-                repeatedRequest().start()
-                awaitNewData(repeatedRequest())
+                awaitNewData(repeatedRequest().start())
 
                 expectResonseText(oldRequest(), text: "No.")        // still has old result
                 expectResonseText(repeatedRequest(), text: "OK, maybe.") // has new result
@@ -303,8 +301,7 @@ class RequestSpec: ResourceSpecBase
                 oldRequest().onCompletion { _ in oldRequestHookCalls += 1 }
 
                 stubRepeatedRequest()
-                repeatedRequest().start()
-                awaitNewData(repeatedRequest())
+                awaitNewData(repeatedRequest().start())
 
                 expect(oldRequestHookCalls) == 1
                 }
@@ -321,8 +318,7 @@ class RequestSpec: ResourceSpecBase
                 service().invalidateConfiguration()
 
                 stubRepeatedRequest(flavorHeader: flavor)
-                repeatedRequest().start()
-                awaitNewData(repeatedRequest())
+                awaitNewData(repeatedRequest().start())
                 }
 
             it("repeats custom response mutation")
@@ -341,9 +337,7 @@ class RequestSpec: ResourceSpecBase
                 awaitNewData(req)
 
                 stubRepeatedRequest(flavorHeader: "mutant flavor 1")
-                let repeated = req.repeated()
-                repeated.start()
-                awaitNewData(repeated)
+                awaitNewData(req.repeated().start())
                 }
 
             it("does not repeat request decorations")
@@ -359,8 +353,7 @@ class RequestSpec: ResourceSpecBase
                     }
 
                 stubRepeatedRequest()
-                repeatedRequest().start()
-                awaitNewData(repeatedRequest())
+                awaitNewData(repeatedRequest().start())
 
                 expect(decorations) == 1
                 }


### PR DESCRIPTION
This makes `repeat()` repeat the initial request of a chained request.

In other words, in this code:

```swift
let req0 = resource.request(.get)
let req1 = req0.chained { …chain logic… }
req1.repeated().start()
```

…Siesta currently reruns the chain logic, but does _not_ repeat `req0`. This PR causes Siesta to repeat req0 first, then rerun the chain logic using the new result.

This fixes #130.

This PR also makes `Request.self()` fluent (i.e. it returns the receiving request).