### PR TITLE
Stronger types for RequestError.Cause properties

### DIFF
--- a/Source/Siesta/Pipeline/ResponseTransformer.swift
+++ b/Source/Siesta/Pipeline/ResponseTransformer.swift
@@ -274,14 +274,15 @@ public func TextResponseTransformer(_ transformErrors: Bool = true) -> ResponseT
     return ResponseContentTransformer<Data, String>(transformErrors: transformErrors)
         {
         let charsetName = $0.charset ?? "ISO-8859-1"
-        let encoding = CFStringConvertEncodingToNSStringEncoding(
+        let encodingID = CFStringConvertEncodingToNSStringEncoding(
             CFStringConvertIANACharSetNameToEncoding(charsetName as CFString))
 
-        guard encoding != UInt(kCFStringEncodingInvalidId) else
+        guard encodingID != UInt(kCFStringEncodingInvalidId) else
             { throw RequestError.Cause.InvalidTextEncoding(encodingName: charsetName) }
 
-        guard let string = String(data: $0.content, encoding: String.Encoding(rawValue: encoding)) else
-            { throw RequestError.Cause.UndecodableText(encodingName: charsetName) }
+        let encoding = String.Encoding(rawValue: encodingID)
+        guard let string = String(data: $0.content, encoding: encoding) else
+            { throw RequestError.Cause.UndecodableText(encoding: encoding) }
 
         return string
         }

--- a/Source/Siesta/Pipeline/ResponseTransformer.swift
+++ b/Source/Siesta/Pipeline/ResponseTransformer.swift
@@ -208,8 +208,8 @@ public struct ResponseContentTransformer<InputContentType, OutputContentType>: R
         return .failure(RequestError(
             userMessage: NSLocalizedString("Cannot parse server response", comment: "userMessage"),
             cause: RequestError.Cause.WrongInputTypeInTranformerPipeline(
-                expectedType: debugStr(InputContentType.self),
-                actualType: debugStr(type(of: entityFromUpstream.content)),
+                expectedType: InputContentType.self,
+                actualType: type(of: entityFromUpstream.content),
                 transformer: self)))
         }
 
@@ -296,7 +296,7 @@ public func JSONResponseTransformer(_ transformErrors: Bool = true) -> ResponseT
         let rawObj = try JSONSerialization.jsonObject(with: $0.content, options: [.allowFragments])
 
         guard let jsonObj = rawObj as? JSONConvertible else
-            { throw RequestError.Cause.JSONResponseIsNotDictionaryOrArray(actualType: debugStr(type(of: rawObj))) }
+            { throw RequestError.Cause.JSONResponseIsNotDictionaryOrArray(actualType: type(of: rawObj)) }
 
         return jsonObj
         }

--- a/Source/Siesta/Request/RequestCreation.swift
+++ b/Source/Siesta/Request/RequestCreation.swift
@@ -49,18 +49,17 @@ public extension Resource
             requestMutation: @escaping (inout URLRequest) -> () = { _ in })
         -> Request
         {
-        let encodingName =
-            CFStringConvertEncodingToIANACharSetName(
-                CFStringConvertNSStringEncodingToEncoding(
-                    encoding.rawValue))
-            as String
-
-        guard let rawBody = text.data(using: encoding) else
+        guard let rawBody = text.data(using: encoding),
+              let encodingName =
+                  CFStringConvertEncodingToIANACharSetName(
+                      CFStringConvertNSStringEncodingToEncoding(
+                          encoding.rawValue))
+        else
             {
             return Resource.failedRequest(
                 RequestError(
                     userMessage: NSLocalizedString("Cannot send request", comment: "userMessage"),
-                    cause: RequestError.Cause.UnencodableText(encodingName: encodingName, text: text)))
+                    cause: RequestError.Cause.UnencodableText(encoding: encoding, text: text)))
             }
 
         return request(method, data: rawBody, contentType: "\(contentType); charset=\(encodingName)", requestMutation: requestMutation)

--- a/Source/Siesta/RequestError.swift
+++ b/Source/Siesta/RequestError.swift
@@ -187,7 +187,7 @@ public extension RequestError
         /// sent a response containing a bare JSON primitive.
         public struct JSONResponseIsNotDictionaryOrArray: Error
             {
-            public let actualType: String
+            public let actualType: Any.Type
             }
 
         /// The server’s response could not be parsed using any known image format.
@@ -198,7 +198,7 @@ public extension RequestError
         /// transformer expected.
         public struct WrongInputTypeInTranformerPipeline: Error
             {
-            public let expectedType, actualType: String  // TODO: Does Swift allow something more inspectable than String? Any.Type & similar don't seem to work.
+            public let expectedType, actualType: Any.Type
             public let transformer: ResponseTransformer
             }
 

--- a/Source/Siesta/RequestError.swift
+++ b/Source/Siesta/RequestError.swift
@@ -143,7 +143,7 @@ public extension RequestError
         /// Unable to create a text request with the requested character encoding.
         public struct UnencodableText: Error
             {
-            public let encodingName: String
+            public let encoding: String.Encoding
             public let text: String
             }
 
@@ -180,7 +180,7 @@ public extension RequestError
         /// The server’s response could not be decoded using the text encoding it specified.
         public struct UndecodableText: Error
             {
-            public let encodingName: String
+            public let encoding: String.Encoding
             }
 
         /// Siesta’s default JSON parser accepts only dictionaries and arrays, but the server

--- a/Tests/Functional/RequestSpec.swift
+++ b/Tests/Functional/RequestSpec.swift
@@ -391,7 +391,7 @@ class RequestSpec: ResourceSpecBase
                 req.onFailure
                     {
                     let cause = $0.cause as? RequestError.Cause.UnencodableText
-                    expect(cause?.encodingName) == "us-ascii"
+                    expect(cause?.encoding) == String.Encoding.ascii
                     expect(cause?.text) == "Hélas!"
                     }
                 }

--- a/Tests/Functional/ResponseDataHandlingSpec.swift
+++ b/Tests/Functional/ResponseDataHandlingSpec.swift
@@ -79,7 +79,7 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                 awaitFailure(resource().load())
 
                 let cause = resource().latestError?.cause as? RequestError.Cause.UndecodableText
-                expect(cause?.encodingName) == "utf-8"
+                expect(cause?.encoding) == String.Encoding.utf8
                 }
 
             it("reports an error if another transformer already made it a string")

--- a/Tests/Functional/ResponseDataHandlingSpec.swift
+++ b/Tests/Functional/ResponseDataHandlingSpec.swift
@@ -88,6 +88,11 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                     { $0.pipeline[.decoding].add(TestTransformer()) }
                 stubText("blah blah", contentType: "text/plain", expectSuccess: false)
                 expect(resource().latestError?.cause is RequestError.Cause.WrongInputTypeInTranformerPipeline) == true
+                if let wrongTypeError = resource().latestError?.cause as? RequestError.Cause.WrongInputTypeInTranformerPipeline
+                    {
+                    print(wrongTypeError.expectedType == Data.self)
+                    print(wrongTypeError.actualType == String.self)
+                    }
                 }
 
             it("transforms error responses")


### PR DESCRIPTION
Swift 3 allows us to use stronger types for several properties of `RequestError.Cause` types that had been plain strings. For example:

- `UndecodableText` now report the attempted character encoding using the `String.Encoding` enum instead of a `String` encoding name.
- `WrongInputTypeInTranformerPipeline` now reports the expected and actual types using `Any.Type`, where Swift 2 had to report only the `String` names of the type.

In all cases, the error causes still give useful descriptive text when printed or logged. This change will only affect clients that inspected those properties — an unusual behavior!