### PR TITLE
Extension safe library

### DIFF
--- a/Siesta.xcodeproj/project.pbxproj
+++ b/Siesta.xcodeproj/project.pbxproj
@@ -1111,6 +1111,7 @@
 		9F2FB5231C28645E0068DFFA /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -1129,6 +1130,7 @@
 		9F2FB5241C28645E0068DFFA /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_IDENTITY = "";
 				COMBINE_HIDPI_IMAGES = YES;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
@@ -1277,6 +1279,7 @@
 		DA336E641B2E6DDB006F702A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/iOS/";
@@ -1292,6 +1295,7 @@
 		DA336E651B2E6DDB006F702A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				FRAMEWORK_SEARCH_PATHS = "$(PROJECT_DIR)/Carthage/Build/iOS/";


### PR DESCRIPTION
This PR enables the `Allow app extension API only` option.
Because there are no non-safe APIs used in the library, it can be enabled without producing any warnings.
This change will hide the `unsafe api` warning, if one uses the framework in an app extension.

SiestaUI can't be labeled `app extension safe`, because of it's NetworkActivityIndicator.