### PR TITLE
Resume alamofire request only and only if it hasn't been started previously

### DIFF
--- a/Extensions/Alamofire/Networking-Alamofire.swift
+++ b/Extensions/Alamofire/Networking-Alamofire.swift
@@ -56,7 +56,9 @@ internal struct AlamofireRequestNetworking: RequestNetworking, SessionTaskContai
     init(_ alamofireRequest: Alamofire.Request)
         {
         self.alamofireRequest = alamofireRequest
-        alamofireRequest.resume()   // in case manager.startRequestsImmediately is false
+        if case .suspended = self.alamofireRequest.task?.state ?? .suspended {
+            alamofireRequest.resume()   // in case manager.startRequestsImmediately is false
+        }
         }
 
     var task: URLSessionTask

--- a/Extensions/Alamofire/Networking-Alamofire.swift
+++ b/Extensions/Alamofire/Networking-Alamofire.swift
@@ -56,7 +56,7 @@ internal struct AlamofireRequestNetworking: RequestNetworking, SessionTaskContai
     init(_ alamofireRequest: Alamofire.Request)
         {
         self.alamofireRequest = alamofireRequest
-        if case .suspended = alamofireRequest.task?.state ?? .suspended
+        if let requestTask = alamofireRequest.task, case .suspended = requestTask.state
             {
             alamofireRequest.resume()   // in case manager.startRequestsImmediately is false
             }

--- a/Extensions/Alamofire/Networking-Alamofire.swift
+++ b/Extensions/Alamofire/Networking-Alamofire.swift
@@ -56,9 +56,10 @@ internal struct AlamofireRequestNetworking: RequestNetworking, SessionTaskContai
     init(_ alamofireRequest: Alamofire.Request)
         {
         self.alamofireRequest = alamofireRequest
-        if case .suspended = self.alamofireRequest.task?.state ?? .suspended {
+        if case .suspended = alamofireRequest.task?.state ?? .suspended
+            {
             alamofireRequest.resume()   // in case manager.startRequestsImmediately is false
-        }
+            }
         }
 
     var task: URLSessionTask


### PR DESCRIPTION
fixes #163 

Tested in the example with starts immediately true || false, now it's working as expected... So no second call for alamofire request resume method.