### PR TITLE
Add URL to RequestError

### DIFF
--- a/Source/Siesta/RequestError.swift
+++ b/Source/Siesta/RequestError.swift
@@ -40,6 +40,9 @@ public struct RequestError: Error
 
     /// The HTTP status code (e.g. 404) if this error came from an HTTP response.
     public var httpStatusCode: Int?
+    
+    /// The URL for the request that this error represents.
+    public var url: URL?
 
     /// The response body if this error came from an HTTP response. Its meaning is API-specific.
     public var entity: Entity<Any>?
@@ -64,6 +67,7 @@ public struct RequestError: Error
             userMessage: String? = nil)
         {
         self.httpStatusCode = response?.statusCode
+        self.url = response?.url
         self.cause = cause
 
         if let content = content

--- a/Source/Siesta/RequestError.swift
+++ b/Source/Siesta/RequestError.swift
@@ -39,7 +39,7 @@ public struct RequestError: Error
     public var userMessage: String
 
     /// The HTTP response if this error came from an HTTP response.
-    public let httpResponse: HTTPURLResponse?
+    public var httpResponse: HTTPURLResponse?
     
     /// The HTTP status code (e.g. 404) if this error came from an HTTP response.
     public var httpStatusCode: Int? {
@@ -94,7 +94,6 @@ public struct RequestError: Error
             cause: Error,
             entity: Entity<Any>? = nil)
         {
-        self.httpResponse = nil
         self.userMessage = userMessage
         self.cause = cause
         self.entity = entity

--- a/Source/Siesta/RequestError.swift
+++ b/Source/Siesta/RequestError.swift
@@ -38,15 +38,8 @@ public struct RequestError: Error
     */
     public var userMessage: String
 
-    /// The HTTP response if this error came from an HTTP response.
-    public var httpResponse: HTTPURLResponse?
-    
     /// The HTTP status code (e.g. 404) if this error came from an HTTP response.
-    public var httpStatusCode: Int? {
-        get {
-            return httpResponse?.statusCode
-        }
-    }
+    public var httpStatusCode: Int?
 
     /// The response body if this error came from an HTTP response. Its meaning is API-specific.
     public var entity: Entity<Any>?
@@ -70,7 +63,7 @@ public struct RequestError: Error
             cause: Error?,
             userMessage: String? = nil)
         {
-        self.httpResponse = response
+        self.httpStatusCode = response?.statusCode
         self.cause = cause
 
         if let content = content
@@ -80,7 +73,7 @@ public struct RequestError: Error
             { self.userMessage = message }
         else if let message = cause?.localizedDescription
             { self.userMessage = message }
-        else if let code = self.httpResponse?.statusCode
+        else if let code = self.httpStatusCode
             { self.userMessage = HTTPURLResponse.localizedString(forStatusCode: code).capitalized }
         else
             { self.userMessage = NSLocalizedString("Request failed", comment: "userMessage") }   // Is this reachable?

--- a/Source/Siesta/RequestError.swift
+++ b/Source/Siesta/RequestError.swift
@@ -38,8 +38,15 @@ public struct RequestError: Error
     */
     public var userMessage: String
 
+    /// The HTTP response if this error came from an HTTP response.
+    public var httpResponse: HTTPURLResponse?
+    
     /// The HTTP status code (e.g. 404) if this error came from an HTTP response.
-    public var httpStatusCode: Int?
+    public var httpStatusCode: Int? {
+        get {
+            return httpResponse?.statusCode
+        }
+    }
 
     /// The response body if this error came from an HTTP response. Its meaning is API-specific.
     public var entity: Entity<Any>?
@@ -63,7 +70,7 @@ public struct RequestError: Error
             cause: Error?,
             userMessage: String? = nil)
         {
-        self.httpStatusCode = response?.statusCode
+        self.httpResponse = response
         self.cause = cause
 
         if let content = content
@@ -73,7 +80,7 @@ public struct RequestError: Error
             { self.userMessage = message }
         else if let message = cause?.localizedDescription
             { self.userMessage = message }
-        else if let code = self.httpStatusCode
+        else if let code = self.httpResponse?.statusCode
             { self.userMessage = HTTPURLResponse.localizedString(forStatusCode: code).capitalized }
         else
             { self.userMessage = NSLocalizedString("Request failed", comment: "userMessage") }   // Is this reachable?

--- a/Source/Siesta/RequestError.swift
+++ b/Source/Siesta/RequestError.swift
@@ -39,7 +39,7 @@ public struct RequestError: Error
     public var userMessage: String
 
     /// The HTTP response if this error came from an HTTP response.
-    public var httpResponse: HTTPURLResponse?
+    public let httpResponse: HTTPURLResponse?
     
     /// The HTTP status code (e.g. 404) if this error came from an HTTP response.
     public var httpStatusCode: Int? {
@@ -94,6 +94,7 @@ public struct RequestError: Error
             cause: Error,
             entity: Entity<Any>? = nil)
         {
+        self.httpResponse = nil
         self.userMessage = userMessage
         self.cause = cause
         self.entity = entity


### PR DESCRIPTION
This pull request adds a `URL` object to the `RequestError` struct that represents the `URL` for the request that the error represents.

# Motivation

We needed a way to access the `URL` that the `RequestError` related to so that when logging `RequestError`s, we could include the `URL` for the request that was causing the error.