### PR TITLE
Support for HEAD and OPTIONS requests

### DIFF
--- a/Source/Siesta/Pipeline/ResponseTransformer.swift
+++ b/Source/Siesta/Pipeline/ResponseTransformer.swift
@@ -117,8 +117,9 @@ public struct ResponseContentTransformer<InputContentType, OutputContentType>: R
     /**
       A closure that both processes the content and describes the required input and output types.
 
-      The first argument will be the `Entity.content` property of the second argument, safely cast
-      to the type expected by the closure.
+      The input will be an `Entity` whose `content` is safely cast to the type expected by the closure.
+      If the response content is not castable to `InputContentType`, then the pipeline skips the closure
+      and replaces the resopnse with a `RequestError` describing the type mismatch.
 
       The closure can throw an error to indicate that parsing failed. If it throws a `RequestError`, that
       error is passed on to the resource as is. Other failures are wrapped in a `RequestError`.

--- a/Source/Siesta/Request/Request.swift
+++ b/Source/Siesta/Request/Request.swift
@@ -15,8 +15,14 @@ import Foundation
 */
 public enum RequestMethod: String
     {
+    /// OPTIONS
+    case options
+
     /// GET
     case get
+
+    /// HEAD. The HTTP method, not the body part.
+    case head
 
     /// POST. Just POST. Doc comment is the same as the enum.
     case post

--- a/Source/Siesta/Request/Request.swift
+++ b/Source/Siesta/Request/Request.swift
@@ -40,7 +40,7 @@ public enum RequestMethod: String
     /// I’m here all week! Thank you for reading the documentation!
     case delete
 
-    internal static let all: [RequestMethod] = [.get, .post, .put, .patch, .delete]
+    internal static let all: [RequestMethod] = [.get, .post, .put, .patch, .delete, .head, .options]
     }
 
 /**

--- a/Source/Siesta/Service.swift
+++ b/Source/Siesta/Service.swift
@@ -282,7 +282,7 @@ open class Service: NSObject
       a transformer that passes the content through unmodified, but requires a specific type:
 
           service.configureTransformer("**") {
-            $0.content as JSONConvertible
+            $0.content as JSONConvertible  // error if content from upstream in pipeline is not JSONConvertible
           }
 
       - SeeAlso: `configure(_:requestMethods:description:configurer:)`

--- a/Tests/Functional/RequestSpec.swift
+++ b/Tests/Functional/RequestSpec.swift
@@ -29,6 +29,17 @@ class RequestSpec: ResourceSpecBase
                 awaitNewData(resource().request(.patch))
                 }
 
+            for (method, httpCode) in [(RequestMethod.head, 200), (RequestMethod.post, 204)]
+                {
+                it("represents response without body as zero-length Data for \(method) → \(httpCode)")
+                    {
+                    _ = stubRequest(resource, "HEAD").andReturn(200)
+                    let req = resource().request(.head)
+                    awaitNewData(req)
+                    req.onSuccess { expect($0.typedContent()) == Data() }
+                    }
+                }
+
             it("sends headers from configuration")
                 {
                 service().configure { $0.headers["Zoogle"] = "frotz" }


### PR DESCRIPTION
Resolves #200. Re the questions in that issue, I decided:

1. HEAD should give zero-length `Data`, not `Void`, for the response content. This is existing behavior for 204 responses (which also do not have response bodies according the HTTP spec). It arguably creates more confusing errors if users try to parse empty responses in the pipeline: “can't parse JSON” for empty data instead of “expected Data, got Void.” However, it creates fewer surprising special cases, and is consistent with the behavior of URLSession.
2. The `configureTransformer(…)` method does not apply to HEAD and OPTIONS by default. This prevents the most common scenario for accidental parsing of empty responses. There is no other special handling in the pipeline.
3. `Request`’s contract is preserved; for HEAD, `onNewData` does indeed indicate that “there _would be_ new data if you made a GET request.”

@yesitsdave, would you mind giving this branch a whirl and see if it suits your needs?