### PR TITLE
Make withParam(…) preserve params with empty values

### DIFF
--- a/Source/Siesta/Support/URL+Siesta.swift
+++ b/Source/Siesta/Support/URL+Siesta.swift
@@ -49,7 +49,7 @@ internal extension URL
         let queryItems = components.queryItems ?? []
         var queryDict = [String:String?](minimumCapacity: queryItems.count)
         for item in queryItems
-            { queryDict[item.name] = item.value }
+            { queryDict[item.name] = item.value ?? "" }
 
         queryMutator(&queryDict)
 

--- a/Tests/Functional/ResourcePathsSpec.swift
+++ b/Tests/Functional/ResourcePathsSpec.swift
@@ -172,6 +172,8 @@ class ResourcePathsSpec: ResourceSpecBase
                 {
                 expect(resourceWithParams().withParam("foo", "").url.absoluteString)
                      == "https://zingle.frotz/v1/a/b?foo&zoogle=oogle"
+                expect(resourceWithParams().withParam("foo", "").withParam("zoogle", "").url.absoluteString)
+                     == "https://zingle.frotz/v1/a/b?foo&zoogle"
                 }
 
             it("treats nil value as removal")


### PR DESCRIPTION
`withParam(…)` was wrongly dropping _existing_ params that were present but had an empty value (e.g. `?x` or `?y=`).

Fixes #222. @ligal, see if this solves your problem.