### PR TITLE
Swift 3.2 on Xcode 9

### DIFF
--- a/Siesta.podspec
+++ b/Siesta.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Siesta"
-  s.version      = "1.2.1"
+  s.version      = "1.2.2"
   s.summary      = "Swift REST client library"
 
   s.description  = <<-DESC
@@ -69,7 +69,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.11"
 
-  s.source = { :git => "https://github.com/bustoutsolutions/siesta.git", :tag => "1.2.1" }
+  s.source = { :git => "https://github.com/bustoutsolutions/siesta.git", :tag => "1.2.2" }
 
   s.subspec "Core" do |s|
     s.source_files = "Source/Siesta/**/*"

--- a/Source/Siesta/Pipeline/PipelineProcessing.swift
+++ b/Source/Siesta/Pipeline/PipelineProcessing.swift
@@ -21,7 +21,7 @@ internal extension Pipeline
             { stage in (stage, stage.cacheBox?.buildEntry(resource)) }
         }
 
-    internal func makeProcessor(_ rawResponse: Response, resource: Resource) -> (Void) -> Response
+    internal func makeProcessor(_ rawResponse: Response, resource: Resource) -> () -> Response
         {
         // Generate cache keys on main thread (because this touches Resource)
         let stagesAndEntries = self.stagesAndEntries(for: resource)
@@ -180,7 +180,7 @@ private struct CacheEntry<Cache, Key>: CacheEntryProtocol
             { self.cache.removeEntity(forKey: self.key) }
         }
 
-    private func dispatchSyncOnWorkQueue<T>(_ action: (Void) -> T) -> T
+    private func dispatchSyncOnWorkQueue<T>(_ action: () -> T) -> T
         {
         var result: T?
         cache.workQueue.sync

--- a/Source/Siesta/Request/NetworkRequest.swift
+++ b/Source/Siesta/Request/NetworkRequest.swift
@@ -17,7 +17,7 @@ internal final class NetworkRequest: RequestWithDefaultCallbacks, CustomDebugStr
         { return resource.configuration(for: underlyingRequest) }
 
     // Networking
-    private let requestBuilder: (Void) -> URLRequest
+    private let requestBuilder: () -> URLRequest
     private let underlyingRequest: URLRequest
     internal var networking: RequestNetworking?  // present only after start()
     internal var underlyingNetworkRequestCompleted = false  // so tests can wait for it to finish
@@ -38,7 +38,7 @@ internal final class NetworkRequest: RequestWithDefaultCallbacks, CustomDebugStr
 
     // MARK: Managing request
 
-    init(resource: Resource, requestBuilder: @escaping (Void) -> URLRequest)
+    init(resource: Resource, requestBuilder: @escaping () -> URLRequest)
         {
         self.resource = resource
         self.requestBuilder = requestBuilder  // for repeated()

--- a/Source/Siesta/Request/Request.swift
+++ b/Source/Siesta/Request/Request.swift
@@ -79,7 +79,7 @@ public protocol Request: class
 
     /// Call the closure once if the request succeeds with a 304.
     @discardableResult
-    func onNotModified(_ callback: @escaping (Void) -> Void) -> Self
+    func onNotModified(_ callback: @escaping () -> Void) -> Self
 
     /// Call the closure once if the request fails for any reason.
     @discardableResult

--- a/Source/Siesta/Request/RequestCallbacks.swift
+++ b/Source/Siesta/Request/RequestCallbacks.swift
@@ -41,7 +41,7 @@ extension RequestWithDefaultCallbacks
             }
         }
 
-    func onNotModified(_ callback: @escaping (Void) -> Void) -> Self
+    func onNotModified(_ callback: @escaping () -> Void) -> Self
         {
         return addResponseCallback
             {

--- a/Source/Siesta/Resource/Resource.swift
+++ b/Source/Siesta/Resource/Resource.swift
@@ -260,7 +260,7 @@ public final class Resource: NSObject
 
         // Build the request
 
-        let requestBuilder: (Void) -> URLRequest =
+            let requestBuilder: () -> URLRequest =
             {
             var underlyingRequest = URLRequest(url: self.url)
             underlyingRequest.httpMethod = method.rawValue.uppercased()
@@ -461,7 +461,7 @@ public final class Resource: NSObject
 
       The `callback` is called aftrer the given delay, regardless of whether the request was cancelled.
     */
-    public func cancelLoadIfUnobserved(afterDelay delay: TimeInterval, then callback: @escaping (Void) -> Void = {})
+    public func cancelLoadIfUnobserved(afterDelay delay: TimeInterval, then callback: @escaping () -> Void = {})
         {
         DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.05)
             {

--- a/Source/Siesta/Resource/ResourceObserver.swift
+++ b/Source/Siesta/Resource/ResourceObserver.swift
@@ -370,8 +370,8 @@ internal class ObserverEntry: CustomStringConvertible
 
     private func withOwner(
             _ owner: AnyObject,
-            ifObserver selfOwnerAction: (Void) -> Void,
-            else externalOwnerAction: (Void) -> Void)
+            ifObserver selfOwnerAction: () -> Void,
+            else externalOwnerAction: () -> Void)
         {
         // TODO: see if isObject() check improves perf here once https://bugs.swift.org/browse/SR-2867 is fixed
         if owner === (observer as AnyObject?)

--- a/Source/Siesta/Support/Progress.swift
+++ b/Source/Siesta/Support/Progress.swift
@@ -101,7 +101,7 @@ internal protocol Progress
 
 extension Progress
     {
-    final var fractionDone: Double
+    var fractionDone: Double
         {
         let raw = rawFractionDone
         return raw.isNaN ? raw : max(0, min(1, raw))

--- a/Source/Siesta/Support/Progress.swift
+++ b/Source/Siesta/Support/Progress.swift
@@ -47,7 +47,7 @@ internal struct RequestProgressComputation: Progress
                 { return nil }
             }
 
-        overallProgress.holdConstant
+        overallProgress = overallProgress.heldConstant
             {
             uploadProgress.actualTotal   = optionalTotal(metrics.requestBytesTotal)
             downloadProgress.actualTotal = optionalTotal(metrics.responseBytesTotal)
@@ -65,7 +65,7 @@ internal struct RequestProgressComputation: Progress
 
         if requestStarted || responseStarted
             {
-            overallProgress.holdConstant
+            overallProgress = overallProgress.heldConstant
                 { connectLatency.complete() }
             }
         else
@@ -73,7 +73,7 @@ internal struct RequestProgressComputation: Progress
 
         if responseStarted
             {
-            overallProgress.holdConstant
+            overallProgress = overallProgress.heldConstant
                 { responseLatency.complete() }
             }
         else if requestSent
@@ -186,13 +186,16 @@ private struct MonotonicProgress: Progress
     var rawFractionDone: Double
         { return (child.fractionDone - 1) * adjustment + 1 }
 
-    mutating func holdConstant(closure: (Void) -> Void)
+    func heldConstant(withRespectTo changes: () -> Void) -> MonotonicProgress
         {
         let before = fractionDone
-        closure()
+        changes()
         let afterRaw = child.fractionDone
+
+        var result = self
         if afterRaw != 1
-            { adjustment = (before - 1) / (afterRaw - 1) }
+            { result.adjustment = (before - 1) / (afterRaw - 1) }
+        return result
         }
     }
 

--- a/Source/Siesta/Support/Siesta-ObjC.swift
+++ b/Source/Siesta/Support/Siesta-ObjC.swift
@@ -192,7 +192,7 @@ public class _objc_Request: NSObject
         return self
         }
 
-    public func onNotModified(_ objcCallback: @escaping @convention(block) (Void) -> Void) -> _objc_Request
+    public func onNotModified(_ objcCallback: @escaping @convention(block) () -> Void) -> _objc_Request
         {
         request.onNotModified(objcCallback)
         return self

--- a/Tests/Functional/RequestSpec.swift
+++ b/Tests/Functional/RequestSpec.swift
@@ -651,7 +651,7 @@ class RequestSpec: ResourceSpecBase
 
                     req.cancel()
                     _ = reqStub.go()
-                    awaitFailure(req, alreadyCompleted: true)
+                    awaitFailure(req)
                     }
 
                 it("does not stop the chain if the underlying request is cancelled")


### PR DESCRIPTION
As discussed in https://github.com/bustoutsolutions/siesta/issues/227 I've followed your instructions and cherry-picked both commits.

This resolves the mentioned issue within our app and removes all runtime errors we encountered before.

I've also removed a couple of Swift 3.2-to-4 warnings covered by Xcode 9 that should be backward-compatible with Xcode 8.

Lastly, I bumped the version to 1.2.2, I hope this was appropriate.

I hope this is of help and looking forward to your review.

Sincerely,
Kaweh