### PR TITLE
Public log methods

### DIFF
--- a/Docs/logging.md
+++ b/Docs/logging.md
@@ -3,13 +3,13 @@
 Siesta features extensive logging. It is disabled by default, but you can turn it on with:
 
 ```swift
-Siesta.LogCategory.enabled = LogCategory.common
+SiestaLog.Category.enabled = .common
 ```
 
 …or for the full fire hose:
 
 ```swift
-Siesta.LogCategory.enabled = LogCategory.all
+SiestaLog.Category.enabled = .all
 ```
 
 Common practice is to add a DEBUG Swift compiler flag to your project (if you haven’t already done so):
@@ -20,7 +20,7 @@ Common practice is to add a DEBUG Swift compiler flag to your project (if you ha
 
 ```swift
 #if DEBUG
-    Siesta.LogCategory.enabled = LogCategory.common
+    SiestaLog.Category.enabled = .common
 #endif
 ```
 

--- a/Examples/GithubBrowser/Source/API/GithubAPI.swift
+++ b/Examples/GithubBrowser/Source/API/GithubAPI.swift
@@ -16,21 +16,21 @@ class _GitHubAPI {
     fileprivate init() {
         #if DEBUG
             // Bare-bones logging of which network calls Siesta makes:
-            LogCategory.enabled = [.network]
+            SiestaLog.Category.enabled = [.network]
 
             // For more info about how Siesta decides whether to make a network call,
             // and which state updates it broadcasts to the app:
 
-            //LogCategory.enabled = LogCategory.common
+            //SiestaLog.Category.enabled = .common
 
             // For the gory details of what Siesta’s up to:
 
-            //LogCategory.enabled = LogCategory.all
+            //SiestaLog.Category.enabled = .detailed
 
             // To dump all requests and responses:
             // (Warning: may cause Xcode console overheating)
 
-            //LogCategory.enabled = LogCategory.all
+            //SiestaLog.Category.enabled = .all
         #endif
 
         // –––––– Global configuration ––––––

--- a/Source/Siesta/ConfigurationPatternConvertible.swift
+++ b/Source/Siesta/ConfigurationPatternConvertible.swift
@@ -75,7 +75,7 @@ extension String: ConfigurationPatternConvertible
                 .replacingOccurrences(of: "\\*",       with: "[^/?]*")
                 .replacingOccurrences(of: "\\?",       with: "[^/?]")
             + "($|\\?)")
-        debugLog(.configuration, ["URL pattern", self, "compiles to regex", pattern.pattern])
+        SiestaLog.log(.configuration, ["URL pattern", self, "compiles to regex", pattern.pattern])
 
         return pattern.configurationPattern(for: service)
         }

--- a/Source/Siesta/Pipeline/PipelineConfiguration.swift
+++ b/Source/Siesta/Pipeline/PipelineConfiguration.swift
@@ -69,7 +69,7 @@ public struct Pipeline
                 .map { key, _ in key }
             let missingStages = Set(nonEmptyStages).subtracting(newValue)
             if !missingStages.isEmpty
-                { debugLog(.pipeline, ["WARNING: Stages", missingStages, "configured but not present in custom pipeline order, will be ignored:", newValue]) }
+                { SiestaLog.log(.pipeline, ["WARNING: Stages", missingStages, "configured but not present in custom pipeline order, will be ignored:", newValue]) }
             }
         }
 

--- a/Source/Siesta/Pipeline/PipelineProcessing.swift
+++ b/Source/Siesta/Pipeline/PipelineProcessing.swift
@@ -31,8 +31,8 @@ internal extension Pipeline
             {
             let result = Pipeline.processAndCache(rawResponse, using: stagesAndEntries)
 
-            debugLog(.pipeline,       ["  └╴Response after pipeline:", result.summary()])
-            debugLog(.networkDetails, ["    Details:", result.dump("      ")])
+            SiestaLog.log(.pipeline,       ["  └╴Response after pipeline:", result.summary()])
+            SiestaLog.log(.networkDetails, ["    Details:", result.dump("      ")])
 
             return result
             }
@@ -55,7 +55,7 @@ internal extension Pipeline
             if case .success(let entity) = output,
                let cacheEntry = cacheEntry
                 {
-                debugLog(.cache, ["  ├╴Caching entity with", type(of: entity.content), "content in", cacheEntry])
+                SiestaLog.log(.cache, ["  ├╴Caching entity with", type(of: entity.content), "content in", cacheEntry])
                 cacheEntry.write(entity)
                 }
 
@@ -134,7 +134,7 @@ extension Pipeline
                 {
                 if let result = cacheEntry?.read()
                     {
-                    debugLog(.cache, ["Cache hit for", cacheEntry])
+                    SiestaLog.log(.cache, ["Cache hit for", cacheEntry])
 
                     let processed = Pipeline.processAndCache(
                         .success(result),
@@ -143,7 +143,7 @@ extension Pipeline
                     switch processed
                         {
                         case .failure:
-                            debugLog(.cache, ["Error processing cached entity; will ignore cached value. Error:", processed])
+                            SiestaLog.log(.cache, ["Error processing cached entity; will ignore cached value. Error:", processed])
 
                         case .success(let entity):
                             return entity

--- a/Source/Siesta/Pipeline/ResponseTransformer.swift
+++ b/Source/Siesta/Pipeline/ResponseTransformer.swift
@@ -49,7 +49,7 @@ public extension ResponseTransformer
     /// Helper to log a transformation. Call this in your custom transformer.
     public func logTransformation(_ result: Response) -> Response
         {
-        debugLog(.pipeline, ["  ├╴Applied transformer:", self, "\n  │ ↳", result.summary()])
+        SiestaLog.log(.pipeline, ["  ├╴Applied transformer:", self, "\n  │ ↳", result.summary()])
         return result
         }
     }
@@ -91,7 +91,7 @@ internal struct ContentTypeMatchTransformer: ResponseTransformer
         if let contentType = contentType,
            contentTypeMatcher.matches(contentType)
             {
-            debugLog(.pipeline, ["  ├╴Transformer", self, "matches content type", debugStr(contentType)])
+            SiestaLog.log(.pipeline, ["  ├╴Transformer", self, "matches content type", debugStr(contentType)])
             return delegate.process(response)
             }
         else
@@ -191,7 +191,7 @@ public struct ResponseContentTransformer<InputContentType, OutputContentType>: R
                 case .skip,
                      .skipIfOutputTypeMatches where entity.content is OutputContentType:
 
-                    debugLog(.pipeline, [self, "skipping transformer because its mismatch rule is", mismatchAction, ", and it expected content of type", InputContentType.self, "but got a", type(of: entity.content)])
+                    SiestaLog.log(.pipeline, [self, "skipping transformer because its mismatch rule is", mismatchAction, ", and it expected content of type", InputContentType.self, "but got a", type(of: entity.content)])
                     return .success(entity)
 
                 case .error,
@@ -241,7 +241,7 @@ public struct ResponseContentTransformer<InputContentType, OutputContentType>: R
                     return logTransformation(.failure(error))
 
                 case .failure(let error):
-                    debugLog(.pipeline, ["Unable to parse error response body; will leave error body unprocessed:", error])
+                    SiestaLog.log(.pipeline, ["Unable to parse error response body; will leave error body unprocessed:", error])
                 }
             }
         return .failure(error)

--- a/Source/Siesta/Request/LiveRequest.swift
+++ b/Source/Siesta/Request/LiveRequest.swift
@@ -159,11 +159,11 @@ private final class LiveRequest: Request, RequestCompletionHandler, CustomDebugS
 
         guard state == .notStarted else
             {
-            debugLog(.networkDetails, [delegate.requestDescription, "already started"])
+            SiestaLog.log(.networkDetails, [delegate.requestDescription, "already started"])
             return self
             }
 
-        debugLog(.network, [delegate.requestDescription])
+        SiestaLog.log(.network, [delegate.requestDescription])
 
         underlyingOperationStarted = true
         delegate.startUnderlyingOperation(passingResponseTo: self)
@@ -181,11 +181,11 @@ private final class LiveRequest: Request, RequestCompletionHandler, CustomDebugS
 
         guard state != .completed else
             {
-            debugLog(.network, ["cancel() called but request already completed:", delegate.requestDescription])
+            SiestaLog.log(.network, ["cancel() called but request already completed:", delegate.requestDescription])
             return
             }
 
-        debugLog(.network, ["Cancelled", delegate.requestDescription])
+        SiestaLog.log(.network, ["Cancelled", delegate.requestDescription])
 
         delegate.cancelUnderlyingOperation()
 
@@ -230,7 +230,7 @@ private final class LiveRequest: Request, RequestCompletionHandler, CustomDebugS
 
         if !existingResponse.isCancellation
             {
-            debugLog(.network,
+            SiestaLog.log(.network,
                 [
                 "WARNING: Received response for request that was already completed:", delegate.requestDescription,
                 "This may indicate a bug in your NetworkingProvider, your custom RequestDelegate, or Siesta itself.",
@@ -244,7 +244,7 @@ private final class LiveRequest: Request, RequestCompletionHandler, CustomDebugS
             // Sometimes the network layer sends a cancellation error. That’s not of interest if we already knew
             // we were cancelled. If we received any other response after cancellation, log that we ignored it.
 
-            debugLog(.networkDetails,
+            SiestaLog.log(.networkDetails,
                 [
                 "Received response, but request was already cancelled:", delegate.requestDescription,
                 "\n    New response:", newResponse

--- a/Source/Siesta/Request/NetworkRequest.swift
+++ b/Source/Siesta/Request/NetworkRequest.swift
@@ -33,7 +33,7 @@ internal final class NetworkRequestDelegate: RequestDelegate
         underlyingRequest = requestBuilder()
 
         requestDescription =
-            LogCategory.enabled.contains(.network) || LogCategory.enabled.contains(.networkDetails)
+            SiestaLog.Category.enabled.contains(.network) || SiestaLog.Category.enabled.contains(.networkDetails)
                 ? debugStr([underlyingRequest.httpMethod, underlyingRequest.url])
                 : "NetworkRequest"
 
@@ -90,9 +90,9 @@ internal final class NetworkRequestDelegate: RequestDelegate
         {
         DispatchQueue.mainThreadPrecondition()
 
-        debugLog(.network, ["Response: ", underlyingResponse?.statusCode ?? error, "←", requestDescription])
-        debugLog(.networkDetails, ["Raw response headers:", underlyingResponse?.allHeaderFields])
-        debugLog(.networkDetails, ["Raw response body:", body?.count ?? 0, "bytes"])
+        SiestaLog.log(.network, ["Response: ", underlyingResponse?.statusCode ?? error, "←", requestDescription])
+        SiestaLog.log(.networkDetails, ["Raw response headers:", underlyingResponse?.allHeaderFields])
+        SiestaLog.log(.networkDetails, ["Raw response body:", body?.count ?? 0, "bytes"])
 
         let responseInfo = interpretResponse(underlyingResponse, body, error)
 

--- a/Source/Siesta/Resource/Resource.swift
+++ b/Source/Siesta/Resource/Resource.swift
@@ -278,7 +278,7 @@ public final class Resource: NSObject
             for configuredMutation in config.requestMutations
                 { configuredMutation(&underlyingRequest) }
 
-            debugLog(.networkDetails, ["Request:", dumpHeaders(underlyingRequest.allHTTPHeaderFields ?? [:], indent: "    ")])
+            SiestaLog.log(.networkDetails, ["Request:", dumpHeaders(underlyingRequest.allHTTPHeaderFields ?? [:], indent: "    ")])
 
             return underlyingRequest
             }
@@ -344,7 +344,7 @@ public final class Resource: NSObject
                 : [name, "expired", deltaFormatted, "sec ago"]
             }
 
-        debugLog(.staleness,
+        SiestaLog.log(.staleness,
             [self, (result ? "is" : "is not"), "up to date:"]
             + formatExpirationTime("error", latestError?.timestamp, configuration.retryTime)
             + ["|"]
@@ -367,7 +367,7 @@ public final class Resource: NSObject
 
         if let loadReq = loadRequests.first
             {
-            debugLog(.staleness, [self, "loadIfNeeded(): load is already in progress: \(loadReq)"])
+            SiestaLog.log(.staleness, [self, "loadIfNeeded(): load is already in progress: \(loadReq)"])
             return loadReq
             }
 
@@ -477,10 +477,10 @@ public final class Resource: NSObject
         DispatchQueue.mainThreadPrecondition()
 
         guard !beingObserved else
-            { return debugLog(.networkDetails, [self, "still has", observers.count, "observer(s), so cancelLoadIfUnobserved() does nothing"]) }
+            { return SiestaLog.log(.networkDetails, [self, "still has", observers.count, "observer(s), so cancelLoadIfUnobserved() does nothing"]) }
 
         if !loadRequests.isEmpty
-            { debugLog(.network, ["Canceling", loadRequests.count, "load request(s) for unobserved", self]) }
+            { SiestaLog.log(.network, ["Canceling", loadRequests.count, "load request(s) for unobserved", self]) }
 
         for req in loadRequests
             { req.cancel() }
@@ -521,7 +521,7 @@ public final class Resource: NSObject
         {
         DispatchQueue.mainThreadPrecondition()
 
-        debugLog(.stateChanges, [self, "received new data from", source, ":", entity])
+        SiestaLog.log(.stateChanges, [self, "received new data from", source, ":", entity])
 
         latestError = nil
         latestData = entity
@@ -538,7 +538,7 @@ public final class Resource: NSObject
 
     private func receiveDataNotModified()
         {
-        debugLog(.stateChanges, [self, "existing data is up to date"])
+        SiestaLog.log(.stateChanges, [self, "existing data is up to date"])
 
         latestError = nil
         latestData?.touch()
@@ -556,7 +556,7 @@ public final class Resource: NSObject
             return
             }
 
-        debugLog(.stateChanges, [self, "received error:", error])
+        SiestaLog.log(.stateChanges, [self, "received error:", error])
 
         latestError = error
 
@@ -660,7 +660,7 @@ public final class Resource: NSObject
         {
         DispatchQueue.mainThreadPrecondition()
 
-        debugLog(.stateChanges, [self, "wiped"])
+        SiestaLog.log(.stateChanges, [self, "wiped"])
 
         for request in allRequests + loadRequests  // need to do both because load(using:) can cross resource boundaries
             { request.cancel() }
@@ -702,7 +702,7 @@ public final class Resource: NSObject
                         [weak self] result in
                         guard let resource = self, resource.latestData == nil else
                             {
-                            debugLog(.cache, ["Ignoring cache hit for", self, " because it is either deallocated or already has data"])
+                            SiestaLog.log(.cache, ["Ignoring cache hit for", self, " because it is either deallocated or already has data"])
                             return
                             }
 

--- a/Source/Siesta/Resource/ResourceObserver.swift
+++ b/Source/Siesta/Resource/ResourceObserver.swift
@@ -267,10 +267,10 @@ public extension Resource
         {
         cleanDefunctObservers(force: true)
 
-        debugLog(.observers, [self, "sending", event, "event to", observers.count, "observer" + (observers.count == 1 ? "" : "s")])
+        SiestaLog.log(.observers, [self, "sending", event, "event to", observers.count, "observer" + (observers.count == 1 ? "" : "s")])
         for entry in observers.values
             {
-            debugLog(.observers, ["  ↳", event, "→", entry.observer])
+            SiestaLog.log(.observers, ["  ↳", event, "→", entry.observer])
             entry.observer?.resourceChanged(self, event: event)
             }
         }
@@ -341,13 +341,13 @@ internal class ObserverEntry: CustomStringConvertible
         {
         self.observerRef = StrongOrWeakRef<ResourceObserver>(observer)
         self.resource = resource
-        if LogCategory.enabled.contains(.observers)
+        if SiestaLog.Category.enabled.contains(.observers)
             { originalObserverDescription = debugStr(observer) }  // So we know what was deallocated if it gets logged
         }
 
     deinit
         {
-        debugLog(.observers, ["removing observer of", resource, "whose owners are all gone:", self])
+        SiestaLog.log(.observers, ["removing observer of", resource, "whose owners are all gone:", self])
         observer?.stoppedObserving(resource: resource)
         }
 

--- a/Source/Siesta/Service.swift
+++ b/Source/Siesta/Service.swift
@@ -143,7 +143,7 @@ open class Service: NSObject
 
         guard let url = urlConvertible.url else
             {
-            debugLog(.network, ["WARNING: Invalid URL:", urlConvertible, "(all requests for this resource will fail)"])
+            SiestaLog.log(.network, ["WARNING: Invalid URL:", urlConvertible, "(all requests for this resource will fail)"])
             return Resource(service: self, invalidURLSource: urlConvertible)  // one-off instance for invalid URL
             }
 
@@ -245,7 +245,7 @@ open class Service: NSObject
             configurationPattern: configurationPattern,
             configurer: configurer)
         configurationEntries.append(entry)
-        debugLog(.configuration, ["Added", entry])
+        SiestaLog.log(.configuration, ["Added", entry])
         }
 
     /**
@@ -373,7 +373,7 @@ open class Service: NSObject
         DispatchQueue.mainThreadPrecondition()
 
         if anyConfigSinceLastInvalidation
-            { debugLog(.configuration, ["Configurations need to be recomputed"]) }
+            { SiestaLog.log(.configuration, ["Configurations need to be recomputed"]) }
         anyConfigSinceLastInvalidation = false
 
         configVersion += 1
@@ -384,16 +384,16 @@ open class Service: NSObject
     internal func configuration(forResource resource: Resource, requestMethod: RequestMethod) -> Configuration
         {
         anyConfigSinceLastInvalidation = true
-        debugLog(.configuration, ["Computing configuration for", requestMethod.rawValue.uppercased(), resource])
+        SiestaLog.log(.configuration, ["Computing configuration for", requestMethod.rawValue.uppercased(), resource])
         var config = Configuration()
         for entry in configurationEntries
             where entry.requestMethods.contains(requestMethod)
                && entry.configurationPattern(resource.url)
             {
-            debugLog(.configuration, ["  ├╴Applying", entry])
+            SiestaLog.log(.configuration, ["  ├╴Applying", entry])
             entry.configurer(&config)
             }
-        debugLog(.configuration, ["  └╴Resulting configuration", config.dump("      ")])
+        SiestaLog.log(.configuration, ["  └╴Resulting configuration", config.dump("      ")])
 
         return config
         }

--- a/Source/Siesta/Support/Logging.swift
+++ b/Source/Siesta/Support/Logging.swift
@@ -53,7 +53,7 @@ public enum SiestaLog
         public static let common: Set<Category> = [network, stateChanges, staleness]
 
         /// Everything except full request/response data.
-        public static let detailed = Set<Category>(all.filter { $0 != networkDetails})
+        public static let detailed = all.subtracting([networkDetails])
 
         /// The whole schebang!
         public static let all: Set<Category> = [network, networkDetails, pipeline, stateChanges, observers, staleness, cache, configuration]
@@ -88,4 +88,17 @@ public enum SiestaLog
         if Category.enabled.contains(category)
             { messageHandler(category, debugStr(messageParts())) }
         }
+    }
+
+// These allow `SiestaLog.Category.enabled = .common` instead of `SiestaLog.Category.enabled = SiestaLog.Category.common`.
+extension Set where Element == SiestaLog.Category
+    {
+    /// A reasonable subset of log categories for normal debugging.
+    public static let common = SiestaLog.Category.common
+
+    /// Everything except full request/response data.
+    public static let detailed = SiestaLog.Category.detailed
+
+    /// The whole kit and caboodle!
+    public static let all = SiestaLog.Category.all
     }

--- a/Source/Siesta/Support/Logging.swift
+++ b/Source/Siesta/Support/Logging.swift
@@ -8,79 +8,84 @@
 
 import Foundation
 
-/**
-  Controls which message Siesta will log. See `enabledLogCategories`.
-
-  - SeeAlso: [Logging Guide](https://github.com/bustoutsolutions/siesta/blob/master/Docs/logging.md)
-*/
-public enum LogCategory
+/// Namespace for Siesta’s logging API.
+public enum SiestaLog
     {
-    /// Summary of network requests: HTTP method, URL, and result code.
-    case network
+    /**
+      Controls which message Siesta will log. See `enabledLogCategories`.
 
-    /// Details of network requests, including headers and bodies.
-    case networkDetails
-
-    /// Details of how the `ResponseTransformer` parses responses.
-    case pipeline
-
-    /// `ResourceEvent` broadcast by resources.
-    case stateChanges
-
-    /// Detailed information about when observers are added, when they are removed, and which events they receive.
-    case observers
-
-    /// Information about how `Resource.loadIfNeeded()` decides whether to initiate a request.
-    case staleness
-
-    /// Details of when resource data is read from & saved to a persistent cache
-    case cache
-
-    /// Details of which configuration matches which resources, and when it is computed.
-    case configuration
-
-    // MARK: Configuring logging
-
-    /// The set of categories to log. Can be changed at runtime.
-    public static var enabled = Set<LogCategory>()
-
-    // MARK: Predefined subsets
-
-    /// A reasonable subset of log categories for normal debugging.
-    public static let common: Set<LogCategory> = [network, stateChanges, staleness]
-
-    /// Everything except full request/response data.
-    public static let detailed = Set<LogCategory>(all.filter { $0 != networkDetails})
-
-    /// The whole schebang!
-    public static let all: Set<LogCategory> = [network, networkDetails, pipeline, stateChanges, observers, staleness, cache, configuration]
-    }
-
-private let maxCategoryNameLength = LogCategory.all.map { Int(String(describing: $0).count) }.max() ?? 0
-
-/// Inject your custom logger to do something other than print to stdout.
-public var logger: (LogCategory, String) -> Void =
-    {
-    let paddedCategory = String(describing: $0).padding(toLength: maxCategoryNameLength, withPad: " ", startingAt: 0)
-    var threadName = ""
-    if !Thread.isMainThread
+      - SeeAlso: [Logging Guide](https://github.com/bustoutsolutions/siesta/blob/master/Docs/logging.md)
+    */
+    public enum Category
         {
-        threadName += "[thread "
-        var threadID = abs(ObjectIdentifier(Thread.current).hashValue &* 524287)
-        for _ in 0..<4
-            {
-            threadName.append(Character(UnicodeScalar(threadID % 0x55 + 0x13a0)!))
-            threadID /= 0x55
-            }
-        threadName += "]"
-        }
-    let prefix = "Siesta:\(paddedCategory) │ \(threadName)"
-    let indentedMessage = $1.replacingOccurrences(of: "\n", with: "\n" + prefix)
-    print(prefix + indentedMessage)
-    }
+        /// Summary of network requests: HTTP method, URL, and result code.
+        case network
 
-internal func debugLog(_ category: LogCategory, _ messageParts: @autoclosure () -> [Any?])
-    {
-    if LogCategory.enabled.contains(category)
-        { logger(category, debugStr(messageParts())) }
+        /// Details of network requests, including headers and bodies.
+        case networkDetails
+
+        /// Details of how the `ResponseTransformer` parses responses.
+        case pipeline
+
+        /// `ResourceEvent` broadcast by resources.
+        case stateChanges
+
+        /// Detailed information about when observers are added, when they are removed, and which events they receive.
+        case observers
+
+        /// Information about how `Resource.loadIfNeeded()` decides whether to initiate a request.
+        case staleness
+
+        /// Details of when resource data is read from & saved to a persistent cache
+        case cache
+
+        /// Details of which configuration matches which resources, and when it is computed.
+        case configuration
+
+        // MARK: Configuring logging
+
+        /// The set of categories to log. Can be changed at runtime.
+        public static var enabled = Set<Category>()
+
+        // MARK: Predefined subsets
+
+        /// A reasonable subset of log categories for normal debugging.
+        public static let common: Set<Category> = [network, stateChanges, staleness]
+
+        /// Everything except full request/response data.
+        public static let detailed = Set<Category>(all.filter { $0 != networkDetails})
+
+        /// The whole schebang!
+        public static let all: Set<Category> = [network, networkDetails, pipeline, stateChanges, observers, staleness, cache, configuration]
+        }
+
+    private static let maxCategoryNameLength = Category.all.map { Int(String(describing: $0).count) }.max() ?? 0
+
+    /// Inject your custom logger to do something other than print to stdout.
+    public static var messageHandler: (Category, String) -> Void =
+        {
+        let paddedCategory = String(describing: $0).padding(toLength: maxCategoryNameLength, withPad: " ", startingAt: 0)
+        var threadName = ""
+        if !Thread.isMainThread
+            {
+            threadName += "[thread "
+            var threadID = abs(ObjectIdentifier(Thread.current).hashValue &* 524287)
+            for _ in 0..<4
+                {
+                threadName.append(Character(UnicodeScalar(threadID % 0x55 + 0x13a0)!))
+                threadID /= 0x55
+                }
+            threadName += "]"
+            }
+        let prefix = "Siesta:\(paddedCategory) │ \(threadName)"
+        let indentedMessage = $1.replacingOccurrences(of: "\n", with: "\n" + prefix)
+        print(prefix + indentedMessage)
+        }
+
+    /// Neatly formats `messageParts` as a message, and logs it to `messageHandler` if `category` is enabled.
+    public static func log(_ category: Category, _ messageParts: @autoclosure () -> [Any?])
+        {
+        if Category.enabled.contains(category)
+            { messageHandler(category, debugStr(messageParts())) }
+        }
     }

--- a/Source/Siesta/Support/Ω_Deprecations.swift
+++ b/Source/Siesta/Support/Ω_Deprecations.swift
@@ -10,7 +10,7 @@ import Foundation
 
 extension Service
     {
-    @available(*, deprecated: 0.99, message: "Use `standardTransformers:` instead of `useDefaultTransformers:`. Choices are `[.json, .text, .image]`; use [] for none")
+    @available(*, deprecated: 1.3, message: "Use `standardTransformers:` instead of `useDefaultTransformers:`. Choices are `[.json, .text, .image]`; use [] for none")
     public convenience init(
             baseURL: URLConvertible? = nil,
             useDefaultTransformers: Bool,
@@ -33,9 +33,20 @@ extension Request
 @available(*, deprecated: 1.4, renamed: "ResponseContentTransformer.InputTypeMismatchAction")
 public typealias InputTypeMismatchAction = ResponseContentTransformer<Any,Any>.InputTypeMismatchAction
 
+
 @available(*, deprecated: 1.4, renamed: "failedRequest(returning:)")
 extension Resource
     {
     public static func failedRequest(_ error: RequestError) -> Request
         { return failedRequest(returning: error) }
+    }
+
+@available(*, deprecated: 1.4, renamed: "SiestaLog.Category")
+public typealias LogCategory = SiestaLog.Category
+
+@available(*, deprecated: 1.4, renamed: "SiestaLog.messageHandler")
+public var logger: (LogCategory, String) -> Void
+    {
+    get { return SiestaLog.messageHandler }
+    set { SiestaLog.messageHandler = newValue }
     }

--- a/Tests/Functional/SiestaSpec.swift
+++ b/Tests/Functional/SiestaSpec.swift
@@ -18,8 +18,8 @@ class SiestaSpec: QuickSpec
         {
         beforeSuite
             {
-            Siesta.LogCategory.enabled = LogCategory.all
-            Siesta.logger = { currentLogMessages.append($1) }
+            SiestaLog.Category.enabled = SiestaLog.Category.all
+            SiestaLog.messageHandler = { currentLogMessages.append($1) }
             }
 
         beforeEach

--- a/Tests/Functional/SiestaSpec.swift
+++ b/Tests/Functional/SiestaSpec.swift
@@ -18,7 +18,7 @@ class SiestaSpec: QuickSpec
         {
         beforeSuite
             {
-            SiestaLog.Category.enabled = SiestaLog.Category.all
+            SiestaLog.Category.enabled = .all
             SiestaLog.messageHandler = { currentLogMessages.append($1) }
             }
 


### PR DESCRIPTION
This allows external modules to log messages to Siesta’s log. It also adds some conveniences for the predefined log category groups & cleans up the top-level namespace a bit.

This is mostly preparatory work for the FileCache landing in a future release, but the ability to say `SiestaLog.Category.enabled = .common` is nice enough that I’m landing this work as a separate PR.