### PR TITLE
Memory leak fix & more sanitization in tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,6 @@ script: |
   echo —————— Running tests for $platform ...
   echo
 
-  Siesta_DelayAfterEachSpec=1 \
   Siesta_TestMultipleNetworkProviders=1 \
   travis_retry xcodebuild test \
       -project Siesta.xcodeproj \

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,10 +1,10 @@
 # Optional integrations
 
-github "Alamofire/Alamofire" ~> 4.0
+github "Alamofire/Alamofire"
 # github "ReactiveCocoa/ReactiveCocoa" "master"  # add to Cartfile if/when it has tests
 
 # Testing
 
-github "Quick/Quick"
+github "pcantrell/Quick" "around-each"
 github "Quick/Nimble"
 github "pcantrell/Nocilla" "siesta"                     # fork adds delay() / go(), nullability annotations

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "Alamofire/Alamofire" "4.7.2"
-github "Quick/Nimble" "v7.1.2"
-github "Quick/Quick" "v1.3.0"
+github "Alamofire/Alamofire" "4.7.3"
+github "Quick/Nimble" "v7.1.3"
 github "pcantrell/Nocilla" "bd7ec7caa0576f08c00bbbf993a9204f93be16e3"
+github "pcantrell/Quick" "30b8c3f5f8b8b9eda6b6e75d1d8bcdef56908997"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "Alamofire/Alamofire" "4.7.3"
 github "Quick/Nimble" "v7.1.3"
 github "pcantrell/Nocilla" "bd7ec7caa0576f08c00bbbf993a9204f93be16e3"
-github "pcantrell/Quick" "30b8c3f5f8b8b9eda6b6e75d1d8bcdef56908997"
+github "pcantrell/Quick" "eeaddb112fc486b1e3699a5985e6a68dd5bc56d8"

--- a/Siesta.xcodeproj/xcshareddata/xcschemes/Siesta iOS.xcscheme
+++ b/Siesta.xcodeproj/xcshareddata/xcschemes/Siesta iOS.xcscheme
@@ -40,6 +40,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
+      enableUBSanitizer = "YES"
       codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
@@ -76,6 +78,11 @@
          </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>
+         <AdditionalOption
+            key = "NSZombieEnabled"
+            value = "YES"
+            isEnabled = "YES">
+         </AdditionalOption>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction

--- a/Siesta.xcodeproj/xcshareddata/xcschemes/Siesta iOS.xcscheme
+++ b/Siesta.xcodeproj/xcshareddata/xcschemes/Siesta iOS.xcscheme
@@ -67,11 +67,6 @@
       </MacroExpansion>
       <EnvironmentVariables>
          <EnvironmentVariable
-            key = "Siesta_DelayAfterEachSpec"
-            value = "$(Siesta_DelayAfterEachSpec)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
             key = "Siesta_TestMultipleNetworkProviders"
             value = "$(Siesta_TestMultipleNetworkProviders)"
             isEnabled = "YES">

--- a/Siesta.xcodeproj/xcshareddata/xcschemes/Siesta macOS.xcscheme
+++ b/Siesta.xcodeproj/xcshareddata/xcschemes/Siesta macOS.xcscheme
@@ -40,6 +40,9 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
+      enableUBSanitizer = "YES"
+      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "NO">
       <Testables>
          <TestableReference
@@ -75,16 +78,26 @@
          </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>
+         <AdditionalOption
+            key = "NSZombieEnabled"
+            value = "YES"
+            isEnabled = "YES">
+         </AdditionalOption>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableASanStackUseAfterReturn = "YES"
+      disableMainThreadChecker = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      stopOnEveryThreadSanitizerIssue = "YES"
+      stopOnEveryUBSanitizerIssue = "YES"
+      stopOnEveryMainThreadCheckerIssue = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>

--- a/Siesta.xcodeproj/xcshareddata/xcschemes/Siesta macOS.xcscheme
+++ b/Siesta.xcodeproj/xcshareddata/xcschemes/Siesta macOS.xcscheme
@@ -67,11 +67,6 @@
       </MacroExpansion>
       <EnvironmentVariables>
          <EnvironmentVariable
-            key = "Siesta_DelayAfterEachSpec"
-            value = "$(Siesta_DelayAfterEachSpec)"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-         <EnvironmentVariable
             key = "Siesta_TestMultipleNetworkProviders"
             value = "$(Siesta_TestMultipleNetworkProviders)"
             isEnabled = "YES">

--- a/Siesta.xcodeproj/xcshareddata/xcschemes/Siesta tvOS.xcscheme
+++ b/Siesta.xcodeproj/xcshareddata/xcschemes/Siesta tvOS.xcscheme
@@ -26,10 +26,16 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
       <AdditionalOptions>
+         <AdditionalOption
+            key = "NSZombieEnabled"
+            value = "YES"
+            isEnabled = "YES">
+         </AdditionalOption>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction

--- a/Siesta.xcodeproj/xcshareddata/xcschemes/Siesta watchOS.xcscheme
+++ b/Siesta.xcodeproj/xcshareddata/xcschemes/Siesta watchOS.xcscheme
@@ -30,6 +30,11 @@
       <Testables>
       </Testables>
       <AdditionalOptions>
+         <AdditionalOption
+            key = "NSZombieEnabled"
+            value = "YES"
+            isEnabled = "YES">
+         </AdditionalOption>
       </AdditionalOptions>
    </TestAction>
    <LaunchAction

--- a/Source/Siesta/Resource/Resource.swift
+++ b/Source/Siesta/Resource/Resource.swift
@@ -376,13 +376,27 @@ public final class Resource: NSObject
 
         if case .inProgress(let cacheRequest) = cacheCheckStatus
             {
+            // isLoading needs to be:
+            //  - false at first,
+            //  - true after loadIfNeeded() while the cache check is in progress, but
+            //  - false again before observers receive a cache hit.
+            //
+            // To make this happen, we need to add the chained cacheThenNetwork below
+            // to loadRequests after it’s created, but remove it _before_ the request
+            // chain proceeds. The trickery with trackedRequest below makes this happen.
+
             var trackedRequest: Request?
+            cacheRequest.onCompletion
+                {
+                _ in self.loadRequests.remove { $0 === trackedRequest }
+                }
+
+            // Now we're ready to construct a chained request that will return either a
+            // cache hit or a bona fide network result.
+
             let cacheThenNetwork = cacheRequest.chained
                 {
                 _ in // We don’t need the result of the cache request here; resource state is already updated
-
-                // Ensure isLoading is false for last event observers receive
-                self.loadRequests.remove { $0 === trackedRequest }
 
                 if self.isUpToDate                 // If cached data is up to date...
                     {
@@ -394,8 +408,10 @@ public final class Resource: NSObject
                     return .passTo(self.load())    // Cache was a bust, so make the real request
                     }
                 }
+
             loadRequests.append(cacheThenNetwork)
             trackedRequest = cacheThenNetwork
+
             return cacheThenNetwork
             }
 

--- a/Source/Siesta/Resource/Resource.swift
+++ b/Source/Siesta/Resource/Resource.swift
@@ -9,8 +9,7 @@ import Foundation
 
 
 // Overridable for testing
-internal var fakeNow: TimeInterval?
-internal let now = { fakeNow ?? Date.timeIntervalSinceReferenceDate }
+internal var now = { Date.timeIntervalSinceReferenceDate }
 
 /**
   An in-memory cache of a RESTful resource, plus information about the status of network requests related to it.

--- a/Source/Siesta/Resource/ResourceObserver.swift
+++ b/Source/Siesta/Resource/ResourceObserver.swift
@@ -420,5 +420,5 @@ private struct ClosureObserver: ResourceObserver, CustomDebugStringConvertible
 extension Resource: WeakCacheValue
     {
     func allowRemovalFromCache()
-        { cleanDefunctObservers() }
+        { cleanDefunctObservers(force: true) }
     }

--- a/Tests/Functional/EntityCacheSpec.swift
+++ b/Tests/Functional/EntityCacheSpec.swift
@@ -86,6 +86,7 @@ class EntityCacheSpec: ResourceSpecBase
                     if let firstRequest = requests.first!
                         { awaitNewData(firstRequest) }
                     expect(resource().isLoading).toEventually(beFalse())
+                    resource().removeObservers(ownedBy: eventRecorder())
                     awaitObserverCleanup(for: resource())
                     }
 

--- a/Tests/Functional/EntityCacheSpec.swift
+++ b/Tests/Functional/EntityCacheSpec.swift
@@ -282,7 +282,8 @@ private class TestCache: EntityCache
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.05)
             { self.receivedCacheRead = true }
 
-        return entries[key]
+        return DispatchQueue.main.sync
+            { entries[key] }
         }
 
     func writeEntity(_ entity: Entity<Any>, forKey key: TestCacheKey)
@@ -295,7 +296,10 @@ private class TestCache: EntityCache
         }
 
     func removeEntity(forKey key: TestCacheKey)
-        { entries.removeValue(forKey: key) }
+        {
+        _ = DispatchQueue.main.sync
+            { entries.removeValue(forKey: key) }
+        }
     }
 
 private struct TestCacheKey

--- a/Tests/Functional/ProgressSpec.swift
+++ b/Tests/Functional/ProgressSpec.swift
@@ -54,8 +54,10 @@ class ProgressSpec: ResourceSpecBase
                 let req = resource().load()
                 req.cancel()
                 expect(req.progress) == 1.0
-                _ = reqStub.go()
                 awaitFailure(req, initialState: .completed)
+
+                _ = reqStub.go()
+                awaitCancelledRequests()
                 }
             }
 

--- a/Tests/Functional/ResourceSpecBase.swift
+++ b/Tests/Functional/ResourceSpecBase.swift
@@ -44,14 +44,6 @@ class ResourceSpecBase: SiestaSpec
             return value == "1" || value == "true"
             }
 
-        if envFlag("DelayAfterEachSpec")
-            {
-            // Nocilla’s threading is broken, and Travis exposes a race condition in it.
-            // This delay is a workaround.
-            print("Using awful sleep workaround for Nocilla’s thread safety problems \u{1f4a9}")
-            afterEach { Thread.sleep(forTimeInterval: 0.02) }  // must happen before clearStubs()
-            }
-
         beforeSuite { LSNocilla.sharedInstance().start() }
         afterSuite  { LSNocilla.sharedInstance().stop() }
         afterEach   { LSNocilla.sharedInstance().clearStubs() }

--- a/Tests/Functional/ResourceSpecBase.swift
+++ b/Tests/Functional/ResourceSpecBase.swift
@@ -100,6 +100,9 @@ class ResourceSpecBase: SiestaSpec
         {
         weak var weakService: Service?
 
+        // Standard service and resource test instances
+        // (These use configurable net provider and embed the spec name in the baseURL.)
+
         let service = specVar
             {
             () -> Service in
@@ -112,8 +115,10 @@ class ResourceSpecBase: SiestaSpec
         let resource = specVar
             { service().resource("/a/b") }
 
-        describe("")
-            { resourceSpec(service, resource) }
+        // Make sure that Service is deallocated after each spec (which also catches Resource and Request leaks,
+        // since they ultimately retain their associated service)
+        //
+        // NB: This must come _after_ the specVars above, which use afterEach to clear the service and resource.
 
         afterEach
             {
@@ -126,6 +131,11 @@ class ResourceSpecBase: SiestaSpec
                 weakService = nil
                 }
             }
+
+        // Run the actual specs
+
+        context("")  // Separate context for service and resource above, so they’re cleaned up before leak check below
+            { resourceSpec(service, resource) }
         }
 
     var baseURL: String

--- a/Tests/Functional/ResourceSpecBase.swift
+++ b/Tests/Functional/ResourceSpecBase.swift
@@ -128,13 +128,27 @@ class ResourceSpecBase: SiestaSpec
 
         afterEach
             {
-            awaitObserverCleanup()
-            weakService?.flushUnusedResources()
+            exampleMetadata in
 
-            if weakService != nil
+            for attempt in 0...
                 {
-                fail("Service instance leaked by test")
-                weakService = nil
+                if weakService == nil
+                    { break }  // yay!
+
+                if attempt > 4
+                    {
+                    fail("Service instance leaked by test")
+                    weakService = nil
+                    break
+                    }
+
+                if attempt > 0  // waiting for one cleanup cycle is normal
+                    {
+                    print("Test may have leaked service instance; will wait for cleanup and check again (attempt \(attempt))")
+                    Thread.sleep(forTimeInterval: 0.02 * pow(3, Double(attempt)))
+                    }
+                awaitObserverCleanup()
+                weakService?.flushUnusedResources()
                 }
             }
 

--- a/Tests/Functional/ResourceSpecBase.swift
+++ b/Tests/Functional/ResourceSpecBase.swift
@@ -223,8 +223,8 @@ func setResourceTime(_ time: TimeInterval)
 //
 // Since there’s no way to directly detect the cleanup, and thus no positive indicator to
 // wait for, we just wait for all tasks currently queued on the main thread to complete.
-
-func awaitObserverCleanup(for resource: Resource?)
+//
+func awaitObserverCleanup(for resource: Resource? = nil)
     {
     let cleanupExpectation = QuickSpec.current.expectation(description: "awaitObserverCleanup")
     DispatchQueue.main.async
@@ -232,3 +232,18 @@ func awaitObserverCleanup(for resource: Resource?)
     QuickSpec.current.waitForExpectations(timeout: 1)
     }
 
+// Request cancellation can cause a race condition in specs:
+//
+// 1. Network request starts chugging
+// 2. Request is cancelled on the Siesta side, but background network machinery already in motion
+// 3. Spec completes, we clear Nocilla stubs
+// 4. Request (which still hasn't received the cancellation) hits Nocilla, causing it to throw
+//    an unstubbed request error
+//
+// Nocilla doesn't provide any way to actually guard against this, or to wait for pending requests
+// to finish, so we solve it with a timeout (pending a better network stubbing lib).
+//
+func awaitCancelledRequests()
+    {
+    Thread.sleep(forTimeInterval: 0.1)
+    }

--- a/Tests/Functional/ResourceSpecBase.swift
+++ b/Tests/Functional/ResourceSpecBase.swift
@@ -120,6 +120,12 @@ class ResourceSpecBase: SiestaSpec
         //
         // NB: This must come _after_ the specVars above, which use afterEach to clear the service and resource.
 
+        aroundEach
+            {
+            example in
+            autoreleasepool { example() }  // Alamofire relies on autorelease, so each spec needs its own pool for leak checking
+            }
+
         afterEach
             {
             awaitObserverCleanup()
@@ -134,8 +140,10 @@ class ResourceSpecBase: SiestaSpec
 
         // Run the actual specs
 
-        context("")  // Separate context for service and resource above, so they’re cleaned up before leak check below
-            { resourceSpec(service, resource) }
+        context("")  // Make specVars above run in a separate context so their afterEach cleans up _before_ the leak check
+            {
+            resourceSpec(service, resource)
+            }
         }
 
     var baseURL: String

--- a/Tests/Functional/ResourceSpecBase.swift
+++ b/Tests/Functional/ResourceSpecBase.swift
@@ -101,16 +101,16 @@ class ResourceSpecBase: SiestaSpec
         weak var weakService: Service?
 
         let service = specVar
-                {
-                () -> Service in
+            {
+            () -> Service in
 
-                let result = serviceBuilder()
-                weakService = result
-                return result
-                }
+            let result = serviceBuilder()
+            weakService = result
+            return result
+            }
 
         let resource = specVar
-                { service().resource("/a/b") }
+            { service().resource("/a/b") }
 
         describe("")
             { resourceSpec(service, resource) }

--- a/Tests/Functional/ResourceStateSpec.swift
+++ b/Tests/Functional/ResourceStateSpec.swift
@@ -11,7 +11,7 @@ import Quick
 import Nimble
 import Nocilla
 
-class ResourceRequestsSpec: ResourceSpecBase
+class ResourceStateSpec: ResourceSpecBase
     {
     override func resourceSpec(_ service: @escaping () -> Service, _ resource: @escaping () -> Resource)
         {
@@ -432,6 +432,8 @@ class ResourceRequestsSpec: ResourceSpecBase
 
                 awaitNewData(request())
                 expect(observerNotified) == true
+
+                resource().removeObservers(ownedBy: request())
                 }
             }
 
@@ -460,6 +462,8 @@ class ResourceRequestsSpec: ResourceSpecBase
 
                 _ = reqStub().go()
                 awaitFailure(req(), initialState: .completed)
+
+                awaitCancelledRequests()
                 }
 
             it("does not cancel if resource has an observer")
@@ -734,6 +738,8 @@ class ResourceRequestsSpec: ResourceSpecBase
                 expect(resource().isLoading) == false
                 expect(resource().latestData).to(beNil())
                 expect(resource().latestError).to(beNil())
+
+                awaitCancelledRequests()
                 }
 
             it("cancels requests attached with load(using:) even if they came from another resource")

--- a/Tests/Functional/ResourceStateSpec.swift
+++ b/Tests/Functional/ResourceStateSpec.swift
@@ -231,7 +231,9 @@ class ResourceStateSpec: ResourceSpecBase
 
                 expect(resource().latestData).to(beNil())
                 expect(resource().latestError).notTo(beNil())
-                expect(resource().latestError?.cause as NSError?) == sampleError
+                let nserror = resource().latestError?.cause as NSError?
+                expect(nserror?.domain) == sampleError.domain
+                expect(nserror?.code) == sampleError.code
                 }
 
             // Testing all these HTTP codes individually because Apple likes

--- a/Tests/Functional/SiestaSpec.swift
+++ b/Tests/Functional/SiestaSpec.swift
@@ -11,6 +11,7 @@ import Quick
 
 private var currentLogMessages: [String] = []
 private var currentTestFailed: Bool = false
+private var activeSuites = 0
 
 class SiestaSpec: QuickSpec
     {
@@ -21,16 +22,11 @@ class SiestaSpec: QuickSpec
             SiestaLog.Category.enabled = .all
             SiestaLog.messageHandler = { currentLogMessages.append($1) }
             }
-
-        beforeEach
-            {
-            currentTestFailed = false
-            currentLogMessages.removeAll(keepingCapacity: true)
             }
 
         afterEach
             {
-            (exampleMetadata: Quick.ExampleMetadata) in
+            exampleMetadata in
 
             resultsAggregator.recordResult(self, example: exampleMetadata.example, passed: !currentTestFailed)
 
@@ -43,11 +39,24 @@ class SiestaSpec: QuickSpec
                 print("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
                 print("")
                 }
+
+            currentTestFailed = false
+            currentLogMessages.removeAll(keepingCapacity: true)
+            }
+
+        beforeSuite
+            {
+            activeSuites += 1
             }
 
         afterSuite
             {
-            resultsAggregator.flush()
+            activeSuites -= 1
+            if activeSuites <= 0
+                {
+                simulateMemoryWarning()
+                resultsAggregator.flush()
+                }
             }
         }
 

--- a/Tests/Functional/SiestaSpec.swift
+++ b/Tests/Functional/SiestaSpec.swift
@@ -98,7 +98,10 @@ private class ResultsAggregator
     func recordResult(_ spec: QuickSpec, example: Example, passed: Bool)
         {
         recordResult(
-            [specDescription(spec)] + example.name.components(separatedBy: ", "),
+            [specDescription(spec)]                 // Test class name
+                + example.name
+                    .components(separatedBy: ", ")  // Quick reports individual test case names separated by commas
+                    .filter { !$0.isEmpty },        // Siesta uses context("") to order its before/after blocks
             subtree: results,
             callsite: example.callsite,
             passed: passed)

--- a/Tests/Functional/SiestaSpec.swift
+++ b/Tests/Functional/SiestaSpec.swift
@@ -20,8 +20,12 @@ class SiestaSpec: QuickSpec
         beforeSuite
             {
             SiestaLog.Category.enabled = .all
-            SiestaLog.messageHandler = { currentLogMessages.append($1) }
-            }
+            SiestaLog.messageHandler =
+                {
+                _, message in
+                DispatchQueue.main.async
+                    { currentLogMessages.append(message) }
+                }
             }
 
         afterEach


### PR DESCRIPTION
Fixes #268.

Adds a basic check for leaked `Service` (and thus `Resource`) instances to the test suite.

Enables assorted Xcode sanitization options in tests.

Fixes several unimportant but now-detected leaks & thread issues in the tests.