### PR TITLE
Fix cancelLoadIfUnobserved(afterDelay), taking the delay into account

### DIFF
--- a/Source/Siesta/Resource/Resource.swift
+++ b/Source/Siesta/Resource/Resource.swift
@@ -506,12 +506,12 @@ public final class Resource: NSObject
       where views are being rapidly discarded and recreated, and you no longer need the resource, but want to give other
       views a chance to express interest in it before canceling any requests.
 
-      The `callback` is called aftrer the given delay, regardless of whether the request was cancelled.
+      The `callback` is called after the given delay, regardless of whether the request was cancelled.
     */
     @objc
     public func cancelLoadIfUnobserved(afterDelay delay: TimeInterval, then callback: @escaping () -> Void = {})
         {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.05)
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay)
             {
             self.cancelLoadIfUnobserved()
             callback()

--- a/Tests/Functional/ResourceStateSpec.swift
+++ b/Tests/Functional/ResourceStateSpec.swift
@@ -515,6 +515,29 @@ class ResourceStateSpec: ResourceSpecBase
                     _ = reqStub().go()
                     awaitNewData(req())
                     }
+
+                it("cancels load after the delay")
+                    {
+                    let expectation = QuickSpec.current.expectation(description: "cancelLoadIfUnobserved(afterDelay:")
+                    resource().cancelLoadIfUnobserved(afterDelay: 0.2)
+                    { expectation.fulfill() }
+                    QuickSpec.current.waitForExpectations(timeout: 0.3)
+
+                    _ = reqStub().go()
+                    awaitFailure(req(), initialState: .completed)
+                    }
+
+                it("does not cancel load before the delay")
+                    {
+                    let expectation = QuickSpec.current.expectation(description: "cancelLoadIfUnobserved(afterDelay:")
+                    expectation.isInverted = true
+                    resource().cancelLoadIfUnobserved(afterDelay: 0.2)
+                    { expectation.fulfill() }
+                    QuickSpec.current.waitForExpectations(timeout: 0.1)
+
+                    _ = reqStub().go()
+                    awaitNewData(req())
+                    }
                 }
             }
 

--- a/Tests/Functional/ResourceStateSpec.swift
+++ b/Tests/Functional/ResourceStateSpec.swift
@@ -520,7 +520,7 @@ class ResourceStateSpec: ResourceSpecBase
                     {
                     let expectation = QuickSpec.current.expectation(description: "cancelLoadIfUnobserved(afterDelay:")
                     resource().cancelLoadIfUnobserved(afterDelay: 0.2)
-                    { expectation.fulfill() }
+                        { expectation.fulfill() }
                     QuickSpec.current.waitForExpectations(timeout: 0.3)
 
                     _ = reqStub().go()
@@ -532,7 +532,7 @@ class ResourceStateSpec: ResourceSpecBase
                     let expectation = QuickSpec.current.expectation(description: "cancelLoadIfUnobserved(afterDelay:")
                     expectation.isInverted = true
                     resource().cancelLoadIfUnobserved(afterDelay: 0.2)
-                    { expectation.fulfill() }
+                        { expectation.fulfill() }
                     QuickSpec.current.waitForExpectations(timeout: 0.1)
 
                     _ = reqStub().go()

--- a/Tests/Functional/ResourceStateSpec.swift
+++ b/Tests/Functional/ResourceStateSpec.swift
@@ -491,7 +491,7 @@ class ResourceStateSpec: ResourceSpecBase
 
             describe("(afterDelay:)")
                 {
-                it("cancels load if resource has loses observers during delay")
+                it("cancels load if resource loses its observers during delay")
                     {
                     let expectation = QuickSpec.current.expectation(description: "cancelLoadIfUnobserved(afterDelay:")
                     resource().addObserver(owner: owner!) { _,_ in }


### PR DESCRIPTION
Before this fix, the delay passed to cancelLoadIfUnobserved(afterDelay) was not used (a value of 0.05 seconds was fixed).
Added new tests.