### PR TITLE
Resource.withParams()

### DIFF
--- a/Examples/GithubBrowser/Source/API/GithubAPI.swift
+++ b/Examples/GithubBrowser/Source/API/GithubAPI.swift
@@ -155,9 +155,11 @@ class _GitHubAPI {
     var activeRepositories: Resource {
         return service
             .resource("/search/repositories")
-            .withParam("q", "stars:>0")
-            .withParam("sort", "updated")
-            .withParam("order", "desc")
+            .withParams([
+                "q": "stars:>0",
+                "sort": "updated",
+                "order": "desc"
+            ])
     }
 
     func user(_ username: String) -> Resource {

--- a/Examples/GithubBrowser/Source/UI/UserViewController.swift
+++ b/Examples/GithubBrowser/Source/UI/UserViewController.swift
@@ -116,7 +116,7 @@ class UserViewController: UIViewController, UISearchBarDelegate, ResourceObserve
 
     func showUser(_ user: User?) {
         // It's often easiest to make the same code path handle both the “data” and “no data” states.
-        // If this UI update were more expensive, we could choose to do it only on ObserverAdded or NewData.
+        // If this UI update were more expensive, we could choose to do it only on observerAdded or newData.
 
         fullNameLabel.text = user?.name
         avatar.imageURL = user?.avatarURL

--- a/Source/Siesta/Resource/ResourceNavigation.swift
+++ b/Source/Siesta/Resource/ResourceNavigation.swift
@@ -98,4 +98,12 @@ extension Resource
             url.alterQuery
                 { $0[name] = value })
         }
+
+    public func withParams(_ params: [String:String?]) -> Resource
+        {
+        var result = self
+        for (key,value) in params
+            { result = result.withParam(key,value) }
+        return result
+        }
     }

--- a/Source/Siesta/Resource/ResourceNavigation.swift
+++ b/Source/Siesta/Resource/ResourceNavigation.swift
@@ -94,16 +94,16 @@ extension Resource
     @objc(withParam:value:)
     public func withParam(_ name: String, _ value: String?) -> Resource
         {
-        return service.resource(absoluteURL:
-            url.alterQuery
-                { $0[name] = value })
+        return withParams([name: value])
         }
 
     public func withParams(_ params: [String:String?]) -> Resource
         {
-        var result = self
-        for (key,value) in params
-            { result = result.withParam(key,value) }
-        return result
+        return service.resource(absoluteURL:
+            url.alterQuery
+                {
+                for (name,value) in params
+                    { $0[name] = value }
+                })
         }
     }

--- a/Source/Siesta/Resource/ResourceNavigation.swift
+++ b/Source/Siesta/Resource/ResourceNavigation.swift
@@ -75,21 +75,26 @@ extension Resource
         }
 
     /**
-      Returns this resource with the given parameter added or changed in the query string.
+      Returns this resource with the given parameter added to or changed in the query string.
 
-      If `value` is an empty string, the parameter goes in the query string with no value (e.g. `?foo`).
-      If `value` is nil, the parameter is removed.
+      If `value` is an empty string, the parameter appears in the query string with no value (e.g. `?foo`).
+
+      If `value` is nil, however, the parameter is removed.
 
       There is no support for parameters with an equal sign but an empty value (e.g. `?foo=`).
       There is also no support for repeated keys in the query string (e.g. `?foo=1&foo=2`).
-      If you need to circumvent either of these restrictions, you can create the query string yourself and pass
-      it to `relative(_:)` instead of using `withParam(_:_:)`.
+      If you need to circumvent either of these restrictions, you can create the query string yourself and pass it to
+      `relative(_:)` instead of using this method. For example:
 
-      Note that `Service` gives out unique `Resource` instances according to the full URL in string form, and thus
-      considers query string parameter order significant. Therefore, to ensure that you get the same `Resource`
-      instance no matter the order in which you specify parameters, `withParam(_:_:)` sorts all parameters by name.
-      Note that _only_ `withParam(_:_:)` does this sorting; if you use other methods to create query strings, it is
-      up to you to canonicalize your parameter order.
+          resource.relative("?foo=1&foo=2")
+
+      - Note: `Service` gives out unique `Resource` instances according to the full URL in string form, and thus
+        considers query string parameter order significant. Therefore, to ensure that you get the same `Resource`
+        instance no matter the order in which you specify parameters, `withParam(_:_:)` sorts _all_ parameters by name,
+        including existing ones. Note that _only_ `withParam(_:_:)` and `withParams(_:)` do this sorting; if you use
+        other methods to create query strings, it is up to you to canonicalize your parameter order.
+
+      - SeeAlso: `withParams(_:)`
     */
     @objc(withParam:value:)
     public func withParam(_ name: String, _ value: String?) -> Resource
@@ -97,6 +102,13 @@ extension Resource
         return withParams([name: value])
         }
 
+    /**
+      Returns this resource with all the entries in the given dictionary added to or changed in the query string.
+      Equivalent to chained calls to `withParam(_:_:)` using each key-value pair in the dictionary.
+
+      See `withParam(_:_:)` for information about the meaning of nil values and empty strings, multi-values params,
+      and canonical parameter ordering.
+    */
     public func withParams(_ params: [String:String?]) -> Resource
         {
         return service.resource(absoluteURL:

--- a/Source/Siesta/Support/Siesta-ObjC.swift
+++ b/Source/Siesta/Support/Siesta-ObjC.swift
@@ -35,6 +35,7 @@ import Foundation
      * Custom ResponseTransformers
      * Custom NetworkingProviders
      * Logging config
+     * Just about anything else configuration-related
 */
 
 // MARK: - Because Swift structs aren’t visible to Obj-C

--- a/Source/Siesta/Support/Siesta-ObjC.swift
+++ b/Source/Siesta/Support/Siesta-ObjC.swift
@@ -154,6 +154,26 @@ extension Resource
     @objc(overrideLocalData:)
     public func _objc_overrideLocalData(_ entity: _objc_Entity)
         { overrideLocalData(with: Entity<Any>.convertedFromObjc(entity)) }
+
+    @objc(withParams:)
+    public func _objc_withParams(_ params: [String:NSObject]) -> Resource
+        {
+        return withParams(
+            params.mapValues
+                {
+                switch $0
+                    {
+                    case let string as String:
+                        return string
+
+                    case is NSNull:
+                        return nil
+
+                    default:
+                        fatalError("Received parameter value that is neither string nor null: \($0)")
+                    }
+                })
+        }
     }
 
 // MARK: - Because Swift closures aren’t exposed as Obj-C blocks

--- a/Tests/Functional/ObjcCompatibilitySpec.m
+++ b/Tests/Functional/ObjcCompatibilitySpec.m
@@ -52,6 +52,7 @@
         _ = [resource child:@"bar"];
         _ = [resource relative:@"../bar"];
         _ = [resource withParam:@"foo" value:@"bar"];
+        _ = [resource withParams:@{@"foo": @"bar", @"baz": NSNull.null}];
         });
 
     it(@"handles requests", ^

--- a/Tests/Functional/ObjcCompatibilitySpec.m
+++ b/Tests/Functional/ObjcCompatibilitySpec.m
@@ -29,7 +29,7 @@
     __block BOSService *service;
     __block BOSResource *resource;
 
-    __block id _;  // Fake Swift’s `_ = foo()` idiom for @discardableResult functions
+    __block id _;  // Fake Swift’s `_ = foo()` idiom for non-@discardableResult functions
 
     beforeEach(^
         {

--- a/Tests/Functional/ResourcePathsSpec.swift
+++ b/Tests/Functional/ResourcePathsSpec.swift
@@ -193,6 +193,13 @@ class ResourcePathsSpec: ResourceSpecBase
                 expect(resourceWithParams().withParam("foo", nil).withParam("zoogle", nil).url.absoluteString)
                      == "https://zingle.frotz/v1/a/b"
                 }
+
+            it("accepts multiple parameters")
+                {
+                let paramDict = ["foo": "bar", "bear": "grrrr", "programmer": "rrrrrg"]
+                expect(resource().withParams(paramDict).url.absoluteString)
+                     == "https://zingle.frotz/v1/a/b?bear=grrrr&foo=bar&programmer=rrrrrg"
+                }
             }
         }
     }

--- a/Tests/Functional/ResourcePathsSpec.swift
+++ b/Tests/Functional/ResourcePathsSpec.swift
@@ -194,11 +194,16 @@ class ResourcePathsSpec: ResourceSpecBase
                      == "https://zingle.frotz/v1/a/b"
                 }
 
-            it("accepts multiple parameters")
+            it("accepts multiple parameters as a dictionary")
                 {
-                let paramDict = ["foo": "bar", "bear": "grrrr", "programmer": "rrrrrg"]
-                expect(resource().withParams(paramDict).url.absoluteString)
-                     == "https://zingle.frotz/v1/a/b?bear=grrrr&foo=bar&programmer=rrrrrg"
+                expect(resourceWithParams().withParams(["dogcow": "moof", "frogbear": "grribbit"]).url.absoluteString)
+                     == "https://zingle.frotz/v1/a/b?dogcow=moof&foo=bar&frogbear=grribbit&zoogle=oogle"
+                }
+
+            it("allows parameter alteration and removal via dictionary")
+                {
+                expect(resourceWithParams().withParams(["foo": "oof", "zoogle": nil]).url.absoluteString)
+                     == "https://zingle.frotz/v1/a/b?foo=oof"
                 }
             }
         }


### PR DESCRIPTION
Adds a `withParams()` method to add multiple params to a `Resource` all at once. This has always been possible with method chaining, but it’s nice to be able to bundle all the params into a dictionary for several reasons:

- It’s slight more concise for many params.
- It can be useful to build up params using dictionary operations.
- It’s _slightly_ faster when adding large numbers of params — and more significantly doesn’t create the cache pressure of creating all the intermediate resources when adding params one by one.