### PR TITLE
Fix SiestaUI library for Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,9 +4,14 @@ import PackageDescription
 let package = Package(
     name: "Siesta",
     products: [
-        .library(name: "Siesta", targets: ["Siesta"])
+        .library(name: "Siesta", targets: ["Siesta"]),
+        .library(name: "SiestaUI", targets: ["SiestaUI"])
     ],
     targets: [
-        .target(name: "Siesta")
+        .target(name: "Siesta"),
+        .target(
+            name: "SiestaUI",
+            dependencies: ["Siesta"]
+        )
     ]
 )

--- a/Source/SiestaUI/Support/Collection+Siesta.swift
+++ b/Source/SiestaUI/Support/Collection+Siesta.swift
@@ -1,0 +1,19 @@
+//
+//  Collection+Siesta.swift
+//  Siesta
+//
+//  Created by Paul on 2015/7/19.
+//  Copyright © 2016 Bust Out Solutions. All rights reserved.
+//
+
+import Foundation
+
+extension Collection
+    {
+    // Just for readability
+    func any(match predicate: (Iterator.Element) -> Bool) -> Bool
+        { return contains(where: predicate) }
+
+    func all(match predicate: (Iterator.Element) -> Bool) -> Bool
+        { return !contains(where: { !predicate($0) }) }
+    }


### PR DESCRIPTION
- SiestaUI library product/target added
- Copy Collection extension into SeistaUI source, fixing an "inaccessable due to 'internal' protection level" error while building