### PR TITLE
Remove dependency on Nocilla

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,18 @@ branches:
 
 language: objective-c
 os: osx
-osx_image: xcode10.2
+osx_image: xcode11.3
 env:
   - scheme='Siesta macOS' platform='OS X'
-  - scheme='Siesta iOS'   platform='iOS Simulator'  sim_os='iOS'  sim_os_version='12.0'  sim_device='iPhone XR'
-  - scheme='Siesta iOS'   platform='iOS Simulator'  sim_os='iOS'  sim_os_version='11.1'  sim_device='iPhone SE'
-  - scheme='Siesta iOS'   platform='iOS Simulator'  sim_os='iOS'  sim_os_version='9.3'   sim_device='iPhone 6'
-  # As of XC 9.4, any framework tests (not just Siesta) fail on iOS 8.1 simulator with
-  # "Timed out trying to establish connection to IDE" (radar 40756466). Reenable this if Apple fixes:
-  #- scheme='Siesta iOS'   platform='iOS Simulator' sim_os='iOS'  sim_os_version='8.1'   sim_device='iPhone 4s'
-  # For now, using 9.3 on 4s instead (which is important bc some bugs are 32-bit-specific):
-  - scheme='Siesta iOS'   platform='iOS Simulator'  sim_os='iOS'  sim_os_version='9.3'   sim_device='iPhone 4s'
-  - scheme='Siesta tvOS'  platform='tvOS Simulator' sim_os='tvOS' sim_os_version='12.1'  sim_device='Apple TV 1080p'
+  - scheme='Siesta iOS'   platform='iOS Simulator'  sim_os='iOS'  sim_os_version='13.3'  sim_device='iPhone 11 Pro'
+  - scheme='Siesta iOS'   platform='iOS Simulator'  sim_os='iOS'  sim_os_version='12.4'  sim_device='iPhone SE'
+  - scheme='Siesta iOS'   platform='iOS Simulator'  sim_os='iOS'  sim_os_version='11.4'   sim_device='iPhone 6'
+
+  ## Travis doesn't include iOS 9 anymore, so we unfortunately can't regression test on a 32-bit device:
+  # - scheme='Siesta iOS'   platform='iOS Simulator' sim_os='iOS'  sim_os_version='9.3'   sim_device='iPhone 4s'
+
+  ## Bundled libraries for tvOS on swift 5.1 are broken; restore when Travis publishes xcode11.4:
+  # - scheme='Siesta tvOS'  platform='tvOS Simulator' sim_os='tvOS' sim_os_version='13.3'  sim_device='Apple TV 4K 1080p'
 
 before_install: |
   set -x
@@ -34,7 +34,7 @@ before_install: |
     # Working for “Library not loaded: /usr/lib/libauto.dylib”; see:
     #   https://stackoverflow.com/questions/55389080/xcode-10-2-failed-to-run-app-on-simulator-with-ios-10
     #   https://developer.apple.com/documentation/xcode_release_notes/xcode_10_2_1_release_notes
-    sudo mkdir "/Library/Developer/CoreSimulator/Profiles/Runtimes/${sim_os} ${sim_os_version}.simruntime/Contents/Resources/RuntimeRoot/usr/lib/swift"
+    # sudo mkdir "/Library/Developer/CoreSimulator/Profiles/Runtimes/${sim_os} ${sim_os_version}.simruntime/Contents/Resources/RuntimeRoot/usr/lib/swift"
   fi
 
 script: |
@@ -60,8 +60,9 @@ script: |
 
   # Import our development certificate.
   security import ".ios-dev-cert.p12" -k "$KEYCHAIN" -P "$KEY_PASSWORD" -T /usr/bin/codesign
-  echo "Available identities after import:"
-  security find-identity
+  ## Slow:
+  # echo "Available identities after import:"
+  # security find-identity
 
   # ------ Tools ------
 

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -7,4 +7,3 @@ github "Alamofire/Alamofire"
 
 github "pcantrell/Quick" "around-each"
 github "Quick/Nimble"
-github "pcantrell/Nocilla" "siesta"                     # fork adds delay() / go(), nullability annotations

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,3 @@
 github "Alamofire/Alamofire" "4.8.1"
 github "Quick/Nimble" "v8.0.1"
-github "pcantrell/Nocilla" "bd7ec7caa0576f08c00bbbf993a9204f93be16e3"
 github "pcantrell/Quick" "eeaddb112fc486b1e3699a5985e6a68dd5bc56d8"

--- a/Siesta.xcodeproj/project.pbxproj
+++ b/Siesta.xcodeproj/project.pbxproj
@@ -24,11 +24,9 @@
 		9F0FB04C1D04179600CE1B61 /* Siesta.h in Headers */ = {isa = PBXBuildFile; fileRef = DA336E521B2E6DDB006F702A /* Siesta.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9F0FB0571D04184F00CE1B61 /* Alamofire.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9F0FB0531D04184F00CE1B61 /* Alamofire.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F0FB0581D04184F00CE1B61 /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9F0FB0541D04184F00CE1B61 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		9F0FB0591D04184F00CE1B61 /* Nocilla.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9F0FB0551D04184F00CE1B61 /* Nocilla.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F0FB05A1D04184F00CE1B61 /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 9F0FB0561D04184F00CE1B61 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F0FB05C1D0418AF00CE1B61 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F0FB0531D04184F00CE1B61 /* Alamofire.framework */; };
 		9F0FB05D1D0418AF00CE1B61 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F0FB0541D04184F00CE1B61 /* Nimble.framework */; };
-		9F0FB05E1D0418AF00CE1B61 /* Nocilla.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F0FB0551D04184F00CE1B61 /* Nocilla.framework */; };
 		9F0FB05F1D0418AF00CE1B61 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F0FB0561D04184F00CE1B61 /* Quick.framework */; };
 		9F2FB5261C2864970068DFFA /* Siesta-ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3FBD9A1B55917600161A25 /* Siesta-ObjC.swift */; };
 		9F2FB5271C2864970068DFFA /* WeakCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9F4BDB1B3DFE3700E8966F /* WeakCache.swift */; };
@@ -180,7 +178,6 @@
 		DA5E4B5622DCEFE40059ED10 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA5E4B5222DCEFE40059ED10 /* Alamofire.framework */; };
 		DA5E4B5722DCEFE40059ED10 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA5E4B5322DCEFE40059ED10 /* Nimble.framework */; };
 		DA5E4B5822DCEFE40059ED10 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA5E4B5422DCEFE40059ED10 /* Quick.framework */; };
-		DA5E4B5922DCEFE40059ED10 /* Nocilla.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA5E4B5522DCEFE40059ED10 /* Nocilla.framework */; };
 		DA5E4B5B22DCF0BB0059ED10 /* SiestaUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA5E4B4B22DCE9670059ED10 /* SiestaUI.framework */; };
 		DA5E4B5C22DCF1260059ED10 /* RemoteImageViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9E515320DD7A45000923BA /* RemoteImageViewSpec.swift */; };
 		DA5E4B5D22DCF12E0059ED10 /* SiestaSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAFA89271B8172920090D283 /* SiestaSpec.swift */; };
@@ -189,7 +186,6 @@
 		DA5E4B6022DCF2610059ED10 /* Networking-Alamofire.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2FF1051C0F97F600C98FF1 /* Networking-Alamofire.swift */; };
 		DA5E4B6222DCF48D0059ED10 /* Alamofire.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = DA5E4B5222DCEFE40059ED10 /* Alamofire.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DA5E4B6322DCF48D0059ED10 /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = DA5E4B5322DCEFE40059ED10 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		DA5E4B6422DCF48D0059ED10 /* Nocilla.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = DA5E4B5522DCEFE40059ED10 /* Nocilla.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DA5E4B6522DCF48D0059ED10 /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = DA5E4B5422DCEFE40059ED10 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DA5EC2741B91E39000DC33C8 /* Networking-URLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5EC2731B91E39000DC33C8 /* Networking-URLSession.swift */; };
 		DA5FE9F41BB9E3EF00B6688A /* Progress.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA5FE9F31BB9E3EF00B6688A /* Progress.swift */; };
@@ -199,8 +195,6 @@
 		DA60F5F91B2F729300D76DC6 /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = DA0B49961B2F68DC00BFBF38 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DA60F5FA1B2F729300D76DC6 /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = DA0B49971B2F68DC00BFBF38 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DA60F5FC1B30B2F800D76DC6 /* Resource.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA60F5FB1B30B2F800D76DC6 /* Resource.swift */; };
-		DA612E451B38AD2100DE9A9F /* Nocilla.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA612E441B38AD2100DE9A9F /* Nocilla.framework */; };
-		DA612E461B38AD3F00DE9A9F /* Nocilla.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = DA612E441B38AD2100DE9A9F /* Nocilla.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DA612E471B38AD6400DE9A9F /* Alamofire.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = DA612E421B38AD1000DE9A9F /* Alamofire.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DA612E4A1B38ADBA00DE9A9F /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA612E421B38AD1000DE9A9F /* Alamofire.framework */; };
 		DA62C9842428670400398674 /* NetworkStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA62C97C2428589B00398674 /* NetworkStub.swift */; };
@@ -347,7 +341,6 @@
 			files = (
 				9F0FB0571D04184F00CE1B61 /* Alamofire.framework in CopyFiles */,
 				9F0FB0581D04184F00CE1B61 /* Nimble.framework in CopyFiles */,
-				9F0FB0591D04184F00CE1B61 /* Nocilla.framework in CopyFiles */,
 				9F0FB05A1D04184F00CE1B61 /* Quick.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -369,7 +362,6 @@
 			files = (
 				DA5E4B6222DCF48D0059ED10 /* Alamofire.framework in CopyFiles */,
 				DA5E4B6322DCF48D0059ED10 /* Nimble.framework in CopyFiles */,
-				DA5E4B6422DCF48D0059ED10 /* Nocilla.framework in CopyFiles */,
 				DA5E4B6522DCF48D0059ED10 /* Quick.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -382,7 +374,6 @@
 			files = (
 				DA60F5F91B2F729300D76DC6 /* Nimble.framework in CopyFiles */,
 				DA60F5FA1B2F729300D76DC6 /* Quick.framework in CopyFiles */,
-				DA612E461B38AD3F00DE9A9F /* Nocilla.framework in CopyFiles */,
 				DA612E471B38AD6400DE9A9F /* Alamofire.framework in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -400,7 +391,6 @@
 		9F0FAFAD1D033FCD00CE1B61 /* Info-macOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-macOS.plist"; sourceTree = "<group>"; };
 		9F0FB0531D04184F00CE1B61 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/Mac/Alamofire.framework; sourceTree = "<group>"; };
 		9F0FB0541D04184F00CE1B61 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/Mac/Nimble.framework; sourceTree = "<group>"; };
-		9F0FB0551D04184F00CE1B61 /* Nocilla.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nocilla.framework; path = Carthage/Build/Mac/Nocilla.framework; sourceTree = "<group>"; };
 		9F0FB0561D04184F00CE1B61 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/Mac/Quick.framework; sourceTree = "<group>"; };
 		9F2FB51E1C28645E0068DFFA /* Siesta.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Siesta.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		9F2FB5221C28645E0068DFFA /* Info-macOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "Info-macOS.plist"; path = "Source/Info-macOS.plist"; sourceTree = SOURCE_ROOT; };
@@ -442,13 +432,11 @@
 		DA5E4B5222DCEFE40059ED10 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/tvOS/Alamofire.framework; sourceTree = "<group>"; };
 		DA5E4B5322DCEFE40059ED10 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/tvOS/Nimble.framework; sourceTree = "<group>"; };
 		DA5E4B5422DCEFE40059ED10 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/tvOS/Quick.framework; sourceTree = "<group>"; };
-		DA5E4B5522DCEFE40059ED10 /* Nocilla.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nocilla.framework; path = Carthage/Build/tvOS/Nocilla.framework; sourceTree = "<group>"; };
 		DA5EC2731B91E39000DC33C8 /* Networking-URLSession.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Networking-URLSession.swift"; sourceTree = "<group>"; };
 		DA5FE9F31BB9E3EF00B6688A /* Progress.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Progress.swift; sourceTree = "<group>"; };
 		DA6022801D65590800FB5673 /* SiestaUI.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SiestaUI.h; sourceTree = "<group>"; };
 		DA60F5FB1B30B2F800D76DC6 /* Resource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Resource.swift; sourceTree = "<group>"; };
 		DA612E421B38AD1000DE9A9F /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
-		DA612E441B38AD2100DE9A9F /* Nocilla.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nocilla.framework; path = Carthage/Build/iOS/Nocilla.framework; sourceTree = "<group>"; };
 		DA62C97C2428589B00398674 /* NetworkStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkStub.swift; sourceTree = "<group>"; };
 		DA7D05C31D57C2B500431980 /* PipelineProcessing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PipelineProcessing.swift; sourceTree = "<group>"; };
 		DA8EF6CF1BC1A917002175EB /* ProgressSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgressSpec.swift; sourceTree = "<group>"; };
@@ -502,7 +490,6 @@
 				DAC4CFCE1DAC10FD00EECEDE /* SiestaUI.framework in Frameworks */,
 				9F0FB05C1D0418AF00CE1B61 /* Alamofire.framework in Frameworks */,
 				9F0FB05D1D0418AF00CE1B61 /* Nimble.framework in Frameworks */,
-				9F0FB05E1D0418AF00CE1B61 /* Nocilla.framework in Frameworks */,
 				9F0FB05F1D0418AF00CE1B61 /* Quick.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -537,7 +524,6 @@
 				DA5E4B5622DCEFE40059ED10 /* Alamofire.framework in Frameworks */,
 				DA5E4B5722DCEFE40059ED10 /* Nimble.framework in Frameworks */,
 				DA5E4B5822DCEFE40059ED10 /* Quick.framework in Frameworks */,
-				DA5E4B5922DCEFE40059ED10 /* Nocilla.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -565,7 +551,6 @@
 				DA612E4A1B38ADBA00DE9A9F /* Alamofire.framework in Frameworks */,
 				DA0B49991B2F68DC00BFBF38 /* Quick.framework in Frameworks */,
 				DA60F5F51B2F723900D76DC6 /* Nimble.framework in Frameworks */,
-				DA612E451B38AD2100DE9A9F /* Nocilla.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -606,7 +591,6 @@
 			children = (
 				9F0FB0531D04184F00CE1B61 /* Alamofire.framework */,
 				9F0FB0541D04184F00CE1B61 /* Nimble.framework */,
-				9F0FB0551D04184F00CE1B61 /* Nocilla.framework */,
 				9F0FB0561D04184F00CE1B61 /* Quick.framework */,
 				570C77E31D38466900226F92 /* ReactiveCocoa.framework */,
 				570C77E51D38468A00226F92 /* Result.framework */,
@@ -725,7 +709,6 @@
 			children = (
 				DA612E421B38AD1000DE9A9F /* Alamofire.framework */,
 				DA0B49961B2F68DC00BFBF38 /* Nimble.framework */,
-				DA612E441B38AD2100DE9A9F /* Nocilla.framework */,
 				DA0B49971B2F68DC00BFBF38 /* Quick.framework */,
 				570C77E01D38463200226F92 /* ReactiveCocoa.framework */,
 				570C77E71D3846A800226F92 /* Result.framework */,
@@ -738,7 +721,6 @@
 			children = (
 				DA5E4B5222DCEFE40059ED10 /* Alamofire.framework */,
 				DA5E4B5322DCEFE40059ED10 /* Nimble.framework */,
-				DA5E4B5522DCEFE40059ED10 /* Nocilla.framework */,
 				DA5E4B5422DCEFE40059ED10 /* Quick.framework */,
 			);
 			name = tvOS;

--- a/Siesta.xcodeproj/project.pbxproj
+++ b/Siesta.xcodeproj/project.pbxproj
@@ -200,6 +200,9 @@
 		DA612E461B38AD3F00DE9A9F /* Nocilla.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = DA612E441B38AD2100DE9A9F /* Nocilla.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DA612E471B38AD6400DE9A9F /* Alamofire.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = DA612E421B38AD1000DE9A9F /* Alamofire.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DA612E4A1B38ADBA00DE9A9F /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA612E421B38AD1000DE9A9F /* Alamofire.framework */; };
+		DA62C9842428670400398674 /* NetworkStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA62C97C2428589B00398674 /* NetworkStub.swift */; };
+		DA62C9852428670500398674 /* NetworkStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA62C97C2428589B00398674 /* NetworkStub.swift */; };
+		DA62C9862428670500398674 /* NetworkStub.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA62C97C2428589B00398674 /* NetworkStub.swift */; };
 		DA7285E61D0DF2D900132CD9 /* OpenEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACE0BAF1D02046500607F3E /* OpenEnum.swift */; };
 		DA7285E71D0DF46600132CD9 /* PipelineSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD191001D0394E300304193 /* PipelineSpec.swift */; };
 		DA788A8E1D6AC1580085C820 /* ObjcCompatibilitySpec.m in Sources */ = {isa = PBXBuildFile; fileRef = DA4D61971B751FEE00F6BB9C /* ObjcCompatibilitySpec.m */; };
@@ -442,6 +445,7 @@
 		DA60F5FB1B30B2F800D76DC6 /* Resource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Resource.swift; sourceTree = "<group>"; };
 		DA612E421B38AD1000DE9A9F /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
 		DA612E441B38AD2100DE9A9F /* Nocilla.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nocilla.framework; path = Carthage/Build/iOS/Nocilla.framework; sourceTree = "<group>"; };
+		DA62C97C2428589B00398674 /* NetworkStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkStub.swift; sourceTree = "<group>"; };
 		DA7D05C31D57C2B500431980 /* PipelineProcessing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PipelineProcessing.swift; sourceTree = "<group>"; };
 		DA8EF6CF1BC1A917002175EB /* ProgressSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgressSpec.swift; sourceTree = "<group>"; };
 		DA99B5C81B38C8E6009C6937 /* String+Siesta.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Siesta.swift"; sourceTree = "<group>"; };
@@ -769,6 +773,7 @@
 				DAFA89271B8172920090D283 /* SiestaSpec.swift */,
 				DA49EA7F1B36174700AE1B8F /* SpecHelpers.swift */,
 				DA4D61991B7521B900F6BB9C /* TestService.swift */,
+				DA62C97C2428589B00398674 /* NetworkStub.swift */,
 			);
 			name = Support;
 			sourceTree = "<group>";
@@ -1357,6 +1362,7 @@
 				DA5A90312054E0C500309D8B /* EntityCacheSpec.swift in Sources */,
 				9F0FAF9B1D033FCD00CE1B61 /* ResourcePathsSpec.swift in Sources */,
 				DA7285E71D0DF46600132CD9 /* PipelineSpec.swift in Sources */,
+				DA62C9852428670500398674 /* NetworkStub.swift in Sources */,
 				9F0FAF9C1D033FCD00CE1B61 /* ResourceSpecBase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1503,6 +1509,7 @@
 				CD5651F21E6F306B009F224A /* ResourcePathsSpec.swift in Sources */,
 				CD5651F81E6F306B009F224A /* ProgressSpec.swift in Sources */,
 				DA5E4B5C22DCF1260059ED10 /* RemoteImageViewSpec.swift in Sources */,
+				DA62C9862428670500398674 /* NetworkStub.swift in Sources */,
 				CD5651F11E6F306B009F224A /* ResourceSpecBase.swift in Sources */,
 				CD5651F41E6F306B009F224A /* ResourceObserversSpec.swift in Sources */,
 				CD5651F91E6F306B009F224A /* WeakCacheSpec.swift in Sources */,
@@ -1579,6 +1586,7 @@
 				DA8EF6D11BC20AFE002175EB /* ProgressSpec.swift in Sources */,
 				DAC0CE6D1B4A3ADA004FBB4B /* ResourceObserversSpec.swift in Sources */,
 				DA49EA801B36174700AE1B8F /* SpecHelpers.swift in Sources */,
+				DA62C9842428670400398674 /* NetworkStub.swift in Sources */,
 				DA9F4BDE1B3F8E2E00E8966F /* WeakCacheSpec.swift in Sources */,
 				DA3314311B4DC11900A7A175 /* ResponseDataHandlingSpec.swift in Sources */,
 				DA9E515420DD7A45000923BA /* RemoteImageViewSpec.swift in Sources */,

--- a/Siesta.xcodeproj/project.pbxproj
+++ b/Siesta.xcodeproj/project.pbxproj
@@ -159,6 +159,9 @@
 		DA3FD66D1D0DF65B00C75742 /* PipelineConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACE0BAD1D0201F800607F3E /* PipelineConfiguration.swift */; };
 		DA3FD66E1D0DF67E00C75742 /* OpenEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACE0BAF1D02046500607F3E /* OpenEnum.swift */; };
 		DA4353521B6AD63C00543843 /* Networking.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4353511B6AD63C00543843 /* Networking.swift */; };
+		DA489AF2242D9B1100BAF782 /* NetworkStub-ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA489AF1242D9A4700BAF782 /* NetworkStub-ObjC.swift */; };
+		DA489AF3242D9B1200BAF782 /* NetworkStub-ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA489AF1242D9A4700BAF782 /* NetworkStub-ObjC.swift */; };
+		DA489AF4242D9B1200BAF782 /* NetworkStub-ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA489AF1242D9A4700BAF782 /* NetworkStub-ObjC.swift */; };
 		DA49EA7C1B35FE5F00AE1B8F /* ServiceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA49EA7B1B35FE5F00AE1B8F /* ServiceSpec.swift */; };
 		DA49EA7E1B35FE7E00AE1B8F /* ResourceSpecBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA49EA7D1B35FE7E00AE1B8F /* ResourceSpecBase.swift */; };
 		DA49EA801B36174700AE1B8F /* SpecHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA49EA7F1B36174700AE1B8F /* SpecHelpers.swift */; };
@@ -428,6 +431,7 @@
 		DA3FBD9A1B55917600161A25 /* Siesta-ObjC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Siesta-ObjC.swift"; sourceTree = "<group>"; };
 		DA3FBDB01B55BF0E00161A25 /* Logging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		DA4353511B6AD63C00543843 /* Networking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Networking.swift; sourceTree = "<group>"; };
+		DA489AF1242D9A4700BAF782 /* NetworkStub-ObjC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NetworkStub-ObjC.swift"; sourceTree = "<group>"; };
 		DA49EA7B1B35FE5F00AE1B8F /* ServiceSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServiceSpec.swift; sourceTree = "<group>"; };
 		DA49EA7D1B35FE7E00AE1B8F /* ResourceSpecBase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResourceSpecBase.swift; sourceTree = "<group>"; };
 		DA49EA7F1B36174700AE1B8F /* SpecHelpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpecHelpers.swift; sourceTree = "<group>"; };
@@ -774,6 +778,7 @@
 				DA49EA7F1B36174700AE1B8F /* SpecHelpers.swift */,
 				DA4D61991B7521B900F6BB9C /* TestService.swift */,
 				DA62C97C2428589B00398674 /* NetworkStub.swift */,
+				DA489AF1242D9A4700BAF782 /* NetworkStub-ObjC.swift */,
 			);
 			name = Support;
 			sourceTree = "<group>";
@@ -1347,6 +1352,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA489AF3242D9B1200BAF782 /* NetworkStub-ObjC.swift in Sources */,
 				DACD23411D60D0FF00848C04 /* RequestSpec.swift in Sources */,
 				9F0FAF901D033FCD00CE1B61 /* ResourceStateSpec.swift in Sources */,
 				9F0FAF911D033FCD00CE1B61 /* Networking-Alamofire.swift in Sources */,
@@ -1521,6 +1527,7 @@
 				DA5E4B6022DCF2610059ED10 /* Networking-Alamofire.swift in Sources */,
 				CD5651F31E6F306B009F224A /* ResourceStateSpec.swift in Sources */,
 				DA5E4B5D22DCF12E0059ED10 /* SiestaSpec.swift in Sources */,
+				DA489AF4242D9B1200BAF782 /* NetworkStub-ObjC.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1598,6 +1605,7 @@
 				DAC0CE691B4A39B0004FBB4B /* ResourcePathsSpec.swift in Sources */,
 				DAD191021D03950100304193 /* PipelineSpec.swift in Sources */,
 				DA49EA7E1B35FE7E00AE1B8F /* ResourceSpecBase.swift in Sources */,
+				DA489AF2242D9B1100BAF782 /* NetworkStub-ObjC.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Siesta.xcodeproj/project.pbxproj
+++ b/Siesta.xcodeproj/project.pbxproj
@@ -1691,7 +1691,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.bustoutsolutions.SiestaTests;
 				PRODUCT_NAME = SiestaTests;
 				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1706,7 +1705,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.bustoutsolutions.SiestaTests;
 				PRODUCT_NAME = SiestaTests;
 				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -1726,7 +1724,6 @@
 				PRODUCT_NAME = Siesta;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -1746,7 +1743,6 @@
 				PRODUCT_NAME = Siesta;
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/Siesta.xcodeproj/xcshareddata/xcschemes/Siesta macOS.xcscheme
+++ b/Siesta.xcodeproj/xcshareddata/xcschemes/Siesta macOS.xcscheme
@@ -40,22 +40,10 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "NO"
       enableThreadSanitizer = "YES"
       enableUBSanitizer = "YES"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "NO">
-      <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "9F0FAF8C1D033FCD00CE1B61"
-               BuildableName = "SiestaTests.xctest"
-               BlueprintName = "SiestaTests macOS"
-               ReferencedContainer = "container:Siesta.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
-      </Testables>
+      codeCoverageEnabled = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -71,6 +59,11 @@
             value = "$(Siesta_TestMultipleNetworkProviders)"
             isEnabled = "YES">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "Siesta_RandomTimeDelayInNetworkStubs"
+            value = "1"
+            isEnabled = "YES">
+         </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>
          <AdditionalOption
@@ -79,6 +72,18 @@
             isEnabled = "YES">
          </AdditionalOption>
       </AdditionalOptions>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "9F0FAF8C1D033FCD00CE1B61"
+               BuildableName = "SiestaTests.xctest"
+               BlueprintName = "SiestaTests macOS"
+               ReferencedContainer = "container:Siesta.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -90,9 +95,7 @@
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
-      stopOnEveryThreadSanitizerIssue = "YES"
-      stopOnEveryUBSanitizerIssue = "YES"
-      stopOnEveryMainThreadCheckerIssue = "YES"
+      migratedStopOnEveryIssue = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
@@ -104,8 +107,6 @@
             ReferencedContainer = "container:Siesta.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Source/Siesta/Networking-URLSession.swift
+++ b/Source/Siesta/Networking-URLSession.swift
@@ -28,7 +28,7 @@ public struct URLSessionProvider: NetworkingProvider
             completion: @escaping RequestNetworkingCompletionCallback)
         -> RequestNetworking
         {
-        let task = self.session.dataTask(with: request)
+        let task = session.dataTask(with: request)
             { completion($1 as? HTTPURLResponse, $0, $2) }
         return URLSessionRequestNetworking(task: task)
         }

--- a/Tests/Functional/EntityCacheSpec.swift
+++ b/Tests/Functional/EntityCacheSpec.swift
@@ -73,7 +73,9 @@ class EntityCacheSpec: ResourceSpecBase
 
                 func loadIfNeededAndRecordEvents(expectingContent content: String)
                     {
-                    _ = stubRequest(resource, "GET").andReturn(200).withBody("net")
+                    NetworkStub.add(
+                        .get, resource,
+                        returning: HTTPResponse(body: "net"))
                     resource().addObserver(eventRecorder())
                     let requests = (1...callCount).map
                         {

--- a/Tests/Functional/EntityCacheSpec.swift
+++ b/Tests/Functional/EntityCacheSpec.swift
@@ -9,7 +9,6 @@
 import Siesta
 import Quick
 import Nimble
-import Nocilla
 
 class EntityCacheSpec: ResourceSpecBase
     {

--- a/Tests/Functional/EntityCacheSpec.swift
+++ b/Tests/Functional/EntityCacheSpec.swift
@@ -209,7 +209,7 @@ class EntityCacheSpec: ResourceSpecBase
                 stubAndAwaitRequest(for: resource())
 
                 setResourceTime(2000)
-                _ = stubRequest(resource, "GET").andReturn(304)
+                NetworkStub.add(.get, resource, status: 304)
                 awaitNotModified(resource().load())
                 expect(testCache.entries[TestCacheKey(forTestResourceIn: testCache)]?.timestamp)
                     .toEventually(equal(2000))

--- a/Tests/Functional/EntityCacheSpec.swift
+++ b/Tests/Functional/EntityCacheSpec.swift
@@ -73,7 +73,7 @@ class EntityCacheSpec: ResourceSpecBase
 
                 func loadIfNeededAndRecordEvents(expectingContent content: String)
                     {
-                    _ = stubRequest(resource, "GET").andReturn(200).withBody("net" as NSString)
+                    _ = stubRequest(resource, "GET").andReturn(200).withBody("net")
                     resource().addObserver(eventRecorder())
                     let requests = (1...callCount).map
                         {

--- a/Tests/Functional/NetworkStub-ObjC.swift
+++ b/Tests/Functional/NetworkStub-ObjC.swift
@@ -1,0 +1,70 @@
+//
+//  NetworkStub-ObjC.swift
+//  Siesta
+//
+//  Created by Paul on 2020/3/26.
+//  Copyright © 2020 Bust Out Solutions. All rights reserved.
+//
+
+// swiftlint:disable function_parameter_count missing_docs
+
+import Foundation
+import Siesta
+
+extension NetworkStub
+    {
+    @objc
+    public static func add(
+            forMethod method: String,
+            resource: Resource,
+            returningStatusCode status: Int)
+        {
+        add(forMethod: method, resource: resource, headers: [:], body: nil, returningStatusCode: status)
+        }
+
+    @objc
+    public static func add(
+            forMethod method: String,
+            resource: Resource,
+            headers requestHeaders: [String:String],
+            body requestBody: String?,
+            returningStatusCode status: Int)
+        {
+        add(forMethod: method, resource: resource, headers: requestHeaders, body: requestBody,
+            returningStatusCode: status, headers: [:], body: nil)
+        }
+
+    @objc
+    public static func add(
+            forMethod method: String,
+            resource: Resource,
+            returningStatusCode status: Int,
+            headers responseHeaders: [String:String],
+            body responseBody: String?)
+        {
+        add(forMethod: method, resource: resource, headers: [:], body: nil,
+            returningStatusCode: status, headers: responseHeaders, body: responseBody)
+        }
+
+    @objc
+    public static func add(
+            forMethod method: String,
+            resource: Resource,
+            headers requestHeaders: [String:String],
+            body requestBody: String?,
+            returningStatusCode status: Int,
+            headers responseHeaders: [String:String],
+            body responseBody: String?)
+        {
+        add(
+            matching: RequestPattern(
+                RequestMethod(rawValue: method.lowercased())!,
+                { resource },
+                headers: requestHeaders,
+                body: requestBody),
+            returning: HTTPResponse(
+                status: status,
+                headers: responseHeaders,
+                body: responseBody))
+        }
+    }

--- a/Tests/Functional/NetworkStub.swift
+++ b/Tests/Functional/NetworkStub.swift
@@ -1,0 +1,273 @@
+//
+//  NetworkStub.swift
+//  Siesta
+//
+//  Created by Paul on 2020/3/22.
+//  Copyright © 2020 Bust Out Solutions. All rights reserved.
+//
+
+import Foundation
+
+private let stubPropertyKey = "\(NetworkStub.self).stub"
+
+private let lock = NSObject()
+func synchronized<T>(_ action: () -> T) -> T
+    {
+    objc_sync_enter(lock)
+    defer { objc_sync_exit(lock) }
+    return action()
+    }
+
+final class NetworkStub: URLProtocol
+    {
+    private static var stubs = [RequestStub]()
+    private static var requestInitialization = Latch(name: "initialization of requests")
+
+    static var defaultConfiguration: URLSessionConfiguration
+        { wrap(URLSessionConfiguration.ephemeral) }
+
+    static func wrap(_ configuration: URLSessionConfiguration) -> URLSessionConfiguration
+        {
+        configuration.protocolClasses = [NetworkStub.self]
+        return configuration
+        }
+
+    static func add(_ stub: RequestStub)
+        {
+        synchronized
+            { stubs.insert(stub, at: 0) }
+        }
+
+    static func clearAll()
+        {
+        Self.requestInitialization.await
+            { stubs = [] }
+        }
+
+    override class func canInit(with request: URLRequest) -> Bool
+        {
+        Self.requestInitialization.increment()
+        return true
+        }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest
+        {
+        synchronized
+            {
+            defer
+                { Self.requestInitialization.decrement() }
+
+            let stubs = Self.stubs
+            guard let stub = stubs.first(where: { $0.matches(request) }) else
+                {
+                fatalError(
+                    """
+                    Unstubbed network request:
+                        \(request.httpMethod ?? "<nil method>") \(request.url?.absoluteString ?? "<nil URL>")
+                        headers: \(request.allHTTPHeaderFields ?? [:])
+                        body: \(request.httpBody?.description ?? "nil")
+
+                    Available stubs:
+                        \(stubs.map { $0.description }.joined(separator: "\n    "))
+
+                    Halting tests
+                    """)
+                }
+
+            let mutableRequest = request as! NSMutableURLRequest
+            URLProtocol.setProperty(stub, forKey: stubPropertyKey, in: mutableRequest)
+            return mutableRequest as URLRequest
+            }
+        }
+
+    override func startLoading()
+        {
+        let stub = URLProtocol.property(forKey: stubPropertyKey, in: request) as! RequestStub
+        stub.delayLatch.await()
+
+        let client = self.client!
+
+        if let error = stub.responseError
+            {
+            client.urlProtocol(self, didFailWithError: error)
+            return
+            }
+        else
+            {
+            Thread.sleep(forTimeInterval: 1.0 / pow(.random(in: 1...1000), 2))
+
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: stub.responseCode,
+                httpVersion: "1.1",
+                headerFields: stub.responseHeaders)!
+            client.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            if let data = stub.responseBody
+                { client.urlProtocol(self, didLoad: data) }
+            }
+
+        client.urlProtocolDidFinishLoading(self)
+        }
+
+    override func stopLoading()
+        { }
+    }
+
+class RequestStub
+    {
+    var method: String
+    var url: String
+
+    init(method: String, url: NSString)
+        {
+        self.method = method
+        self.url = url as String
+        }
+
+    var requestHeaders = [String:String]()
+    var requestBody: Data?
+
+    var responseError: Error?
+    var responseCode = 200
+    var responseHeaders = [String:String]()
+    var responseBody: Data?
+
+    let delayLatch = Latch(name: "delayed request")
+
+    func matches(_ request: URLRequest) -> Bool
+        {
+        return request.httpMethod == method
+            && request.url?.absoluteString == url
+            && requestHeaders.allSatisfy
+                {
+                key, value in
+                request.allHTTPHeaderFields?[key] == value
+                }
+        }
+
+    var description: String
+        { "\(method) \(url) requestHeaders=\(requestHeaders) body=\(requestBody?.description ?? "<any>")" }
+    }
+
+
+func stubRequest(_ method: String, _ url: NSString) -> LSStubRequestDSL
+    {
+    let stub = RequestStub(method: method, url: url)
+    NetworkStub.add(stub)
+    return LSStubRequestDSL(stub: stub)
+    }
+
+class LSStubRequestDSL
+    {
+    var stub: RequestStub
+
+    init(stub: RequestStub)
+        { self.stub = stub }
+
+    func withHeader(_ key: String, _ value: String?) -> Self
+        {
+        synchronized
+            { stub.requestHeaders[key] = value }
+        return self
+        }
+
+    func withBody(_ string: NSString) -> Self
+        { withBody(string.data(using: String.Encoding.utf8.rawValue)!) }
+
+    func withBody(_ data: NSData) -> Self
+        { withBody(data as Data) }
+
+    func withBody(_ data: Data) -> Self
+        {
+        stub.requestBody = data
+        return self
+        }
+
+    func andReturn(_ statusCode: Int) -> LSStubResponseDSL
+        {
+        stub.responseCode = statusCode
+        return LSStubResponseDSL(stub: stub)
+        }
+
+    func andFailWithError(_ error: Error)
+        {
+        stub.responseError = error
+        }
+    }
+
+class LSStubResponseDSL
+    {
+    var stub: RequestStub
+
+    init(stub: RequestStub)
+        { self.stub = stub }
+
+    func withHeader(_ key: String, _ value: String?) -> Self
+        {
+        stub.responseHeaders[key] = value
+        return self
+        }
+
+    func withBody(_ string: NSString?) -> Self
+        { withBody(string?.data(using: String.Encoding.utf8.rawValue)!) }
+
+    func withBody(_ data: NSData?) -> Self
+        { withBody(data as Data?) }
+
+    func withBody(_ data: Data?) -> Self
+        {
+        stub.responseBody = data
+        return self
+        }
+
+    func delay() -> Self
+        {
+        stub.delayLatch.increment()
+        return self
+        }
+
+    func go() -> Self
+        {
+        stub.delayLatch.decrement()
+        return self
+        }
+    }
+
+struct LSNocilla
+    {
+    static func sharedInstance() -> Self
+        { LSNocilla() }
+
+    func clearStubs()
+        { NetworkStub.clearAll() }
+    }
+
+struct Latch
+    {
+    private var lock = NSConditionLock(condition: 0)
+
+    let name: String
+
+    init(name: String)
+        { self.name = name }
+
+    func increment()
+        { add(1) }
+
+    func decrement()
+        { add(-1) }
+
+    private func add(_ delta: Int)
+        {
+        lock.lock()
+        lock.unlock(withCondition: lock.condition + delta)
+        }
+
+    func await(target: Int = 0, whileLocked action: () -> Void = {})
+        {
+        guard lock.lock(whenCondition: target, before: Date(timeIntervalSinceNow: 1)) else
+            { fatalError("timed out waiting for \(name)") }
+        action()
+        lock.unlock()
+        }
+    }

--- a/Tests/Functional/NetworkStub.swift
+++ b/Tests/Functional/NetworkStub.swift
@@ -33,6 +33,17 @@ final class NetworkStub: URLProtocol
         return configuration
         }
 
+    static func add(
+            _ method: RequestMethod,
+            _ resource: @escaping () -> Resource,
+            status: Int = 200)
+        {
+        add(RequestStub(
+            method: method.rawValue.uppercased(),
+            url: resource().url.absoluteString,
+            status: status))
+        }
+
     static func add(_ stub: RequestStub)
         {
         synchronized
@@ -119,17 +130,18 @@ class RequestStub
     var method: String
     var url: String
 
-    init(method: String, url: String)
+    init(method: String, url: String, status: Int = 200)
         {
         self.method = method
         self.url = url
+        self.responseCode = status
         }
 
     var requestHeaders = [String:String]()
     var requestBody: Data?
 
     var responseError: Error?
-    var responseCode = 200
+    var responseCode: Int
     var responseHeaders = [String:String]()
     var responseBody: Data?
 

--- a/Tests/Functional/NetworkStub.swift
+++ b/Tests/Functional/NetworkStub.swift
@@ -134,7 +134,8 @@ final class NetworkStub: URLProtocol
         let stub = URLProtocol.property(forKey: stubPropertyKey, in: request) as! RequestStub
         stub.awaitPermissionToGo()
 
-        Thread.sleep(forTimeInterval: 1.0 / pow(.random(in: 1...1000), 2))
+        if SiestaSpec.envFlag("RandomTimeDelayInNetworkStubs")
+            { Thread.sleep(forTimeInterval: 1.0 / pow(.random(in: 5...100), 2)) }
 
         stub.response.send(to: self.client!, for: self, url: request.url!)
         }

--- a/Tests/Functional/NetworkStub.swift
+++ b/Tests/Functional/NetworkStub.swift
@@ -118,10 +118,10 @@ class RequestStub
     var method: String
     var url: String
 
-    init(method: String, url: NSString)
+    init(method: String, url: String)
         {
         self.method = method
-        self.url = url as String
+        self.url = url
         }
 
     var requestHeaders = [String:String]()
@@ -150,7 +150,7 @@ class RequestStub
     }
 
 
-func stubRequest(_ method: String, _ url: NSString) -> LSStubRequestDSL
+func stubRequest(_ method: String, _ url: String) -> LSStubRequestDSL
     {
     let stub = RequestStub(method: method, url: url)
     NetworkStub.add(stub)
@@ -171,11 +171,8 @@ class LSStubRequestDSL
         return self
         }
 
-    func withBody(_ string: NSString) -> Self
-        { withBody(string.data(using: String.Encoding.utf8.rawValue)!) }
-
-    func withBody(_ data: NSData) -> Self
-        { withBody(data as Data) }
+    func withBody(_ string: String) -> Self
+        { withBody(string.data(using: .utf8)!) }
 
     func withBody(_ data: Data) -> Self
         {
@@ -208,11 +205,8 @@ class LSStubResponseDSL
         return self
         }
 
-    func withBody(_ string: NSString?) -> Self
-        { withBody(string?.data(using: String.Encoding.utf8.rawValue)!) }
-
-    func withBody(_ data: NSData?) -> Self
-        { withBody(data as Data?) }
+    func withBody(_ string: String?) -> Self
+        { withBody(string?.data(using: .utf8)!) }
 
     func withBody(_ data: Data?) -> Self
         {

--- a/Tests/Functional/NetworkStub.swift
+++ b/Tests/Functional/NetworkStub.swift
@@ -9,7 +9,7 @@
 import Foundation
 import Siesta
 
-final class NetworkStub
+public final class NetworkStub: NSObject  // Could be enum but for Obj-C compatibility
     {
     private static var _stubs = [RequestStub]()
     private static let stubsAccessQueue = DispatchQueue(label: "NetworkStub.stubs access")
@@ -70,7 +70,8 @@ final class NetworkStub
             { _stubs.insert(stub, at: 0) }
         }
 
-    static func clearAll()
+    @objc
+    public static func clearAll()
         {
         StubbedNetworkProtocol.afterPendingRequestsStubbed
             {
@@ -118,7 +119,7 @@ private final class StubbedNetworkProtocol: URLProtocol
                 Unstubbed network request:
                     \(request.httpMethod ?? "<nil method>") \(request.url?.absoluteString ?? "<nil URL>")
                     headers: \(request.allHTTPHeaderFields ?? [:])
-                    body: \(body?.description ?? "nil")
+                    body: \(body?.dataDump ?? "nil")
 
                 Available stubs:
                     \(stubs.map { $0.description }.joined(separator: "\n    "))
@@ -310,5 +311,14 @@ private struct Latch
             { fatalError("timed out waiting for \(name)") }
         action()
         lock.unlock()
+        }
+    }
+
+extension Data
+    {
+    var dataDump: String
+        {
+        String(data: self, encoding: .utf8)
+            ?? map { String(format: "%02hhx ", $0) }.joined()
         }
     }

--- a/Tests/Functional/NetworkStub.swift
+++ b/Tests/Functional/NetworkStub.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Siesta
 
 private let stubPropertyKey = "\(NetworkStub.self).stub"
 
@@ -149,10 +150,10 @@ class RequestStub
         { "\(method) \(url) requestHeaders=\(requestHeaders) body=\(requestBody?.description ?? "<any>")" }
     }
 
-
-func stubRequest(_ method: String, _ url: String) -> LSStubRequestDSL
+@discardableResult
+func stubRequest(_ resource: () -> Resource, _ method: String) -> LSStubRequestDSL
     {
-    let stub = RequestStub(method: method, url: url)
+    let stub = RequestStub(method: method, url: resource().url.absoluteString)
     NetworkStub.add(stub)
     return LSStubRequestDSL(stub: stub)
     }

--- a/Tests/Functional/ObjcCompatibilitySpec.m
+++ b/Tests/Functional/ObjcCompatibilitySpec.m
@@ -43,9 +43,9 @@
         resource = nil;
         });
 
-    beforeSuite(^{ [LSNocilla.sharedInstance start]; });
-    afterSuite( ^{ [LSNocilla.sharedInstance stop]; });
-    afterEach(  ^{ [LSNocilla.sharedInstance clearStubs]; });
+    beforeEach(^{ [LSNocilla.sharedInstance start]; });
+    afterEach( ^{ [LSNocilla.sharedInstance clearStubs]; });
+    afterEach( ^{ [LSNocilla.sharedInstance stop]; });
 
     it(@"handles resource paths", ^
         {

--- a/Tests/Functional/ObjcCompatibilitySpec.m
+++ b/Tests/Functional/ObjcCompatibilitySpec.m
@@ -9,7 +9,6 @@
 #import <Siesta/Siesta.h>
 #import <Quick/Quick.h>
 #import <Nimble/Nimble.h>
-#import <Nocilla/Nocilla.h>
 #import "SiestaTests-Swift.h"
 
 @interface ObjcCompatibilitySpec : QuickSpec
@@ -26,10 +25,12 @@
     // These specs are mostly just concerned with whether the code compiles.
     // They don't make many assertions about behavior, which is tested elsewhere.
 
-    __block BOSService *service;
+    __block TestService *service;
     __block BOSResource *resource;
 
-    __block id _;  // Fake Swift’s `_ = foo()` idiom for non-@discardableResult functions
+    __block id _;  // Fake version of Swift’s `_ = foo()` idiom for non-@discardableResult functions
+
+    __block NSMutableArray *allRequests;
 
     beforeEach(^
         {
@@ -37,15 +38,18 @@
         resource = [service resource:@"/foo"];
         });
 
+    beforeEach(^
+        {
+        allRequests = [NSMutableArray array];
+        });
+
     afterEach(^
         {
+        [service awaitAllRequests];
+        [NetworkStub clearAll];
         service = nil;
         resource = nil;
         });
-
-    beforeEach(^{ [LSNocilla.sharedInstance start]; });
-    afterEach( ^{ [LSNocilla.sharedInstance clearStubs]; });
-    afterEach( ^{ [LSNocilla.sharedInstance stop]; });
 
     it(@"handles resource paths", ^
         {
@@ -57,31 +61,44 @@
 
     it(@"handles requests", ^
         {
-        stubRequest(@"GET", @"http://example.api/foo").andReturn(200);
-        stubRequest(@"POST", @"http://example.api/foo").andReturn(200);
-
+        [NetworkStub addForMethod:@"GET" resource:resource returningStatusCode:200];
         expect([resource loadIfNeeded]).notTo(beNil());
         _ = [resource load];
+
+        [NetworkStub addForMethod:@"POST" resource:resource returningStatusCode:200];
         _ = [resource requestWithMethod:@"DELETE" data:[[NSData alloc] init] contentType:@"foo/bar" requestMutation:
             ^(NSMutableURLRequest *req)
                 { req.HTTPMethod = @"POST"; }];
+
+        [NetworkStub addForMethod:@"POST" resource:resource headers:@{@"Content-Type": @"application/json"} body:@"{\"foo\":\"bar\"}" returningStatusCode:200];
         _ = [resource requestWithMethod:@"POST" json:@{@"foo": @"bar"}];
+
+        [NetworkStub addForMethod:@"POST" resource:resource headers:@{@"Content-Type": @"foo/bar"} body:@"{\"foo\":\"bar\"}" returningStatusCode:200];
         _ = [resource requestWithMethod:@"POST" json:@{@"foo": @"bar"} contentType:@"foo/bar" requestMutation:nil];
+
+        [NetworkStub addForMethod:@"POST" resource:resource headers:@{@"Content-Type": @"text/plain; charset=utf-8"} body:@"Ahoy" returningStatusCode:200];
         _ = [resource requestWithMethod:@"POST" text:@"Ahoy"];
+
+        [NetworkStub addForMethod:@"POST" resource:resource headers:@{@"Content-Type": @"foo/bar; charset=us-ascii"} body:@"Ahoy" returningStatusCode:200];
         _ = [resource requestWithMethod:@"POST" text:@"Ahoy" contentType:@"foo/bar" encoding:NSASCIIStringEncoding requestMutation:nil];
+
+        [NetworkStub addForMethod:@"POST" resource:resource headers:@{@"Content-Type": @"application/x-www-form-urlencoded"} body:@"foo=bar" returningStatusCode:200];
         _ = [resource requestWithMethod:@"POST" urlEncoded:@{@"foo": @"bar"} requestMutation:nil];
+
+        [NetworkStub addForMethod:@"POST" resource:resource headers:@{} body:@"{\"foo\":\"bar\"}" returningStatusCode:200];
         _ = [resource loadUsingRequest:[resource requestWithMethod:@"POST" json:@{@"foo": @"bar"}]];
 
-        XCTestExpectation *expectation = [[QuickSpec current] expectationWithDescription:@"network calls finished"];
+        XCTestExpectation *expectation = [[QuickSpec current] expectationWithDescription:@"callback called"];
         BOSRequest *req = [[[[[[resource load]
             onCompletion:
                 ^(BOSEntity *entity, BOSError *error)
                     { [expectation fulfill]; }]
             onSuccess: ^(BOSEntity *entity) { }]
-            onNewData: ^(BOSEntity *entity) { }]  // TODO: This line leaks Resource instances, but the previous line doesn't. ‽‽‽
+            onNewData: ^(BOSEntity *entity) { }]
             onNotModified: ^{ }]
             onFailure: ^(BOSError *error) { }];
         [[QuickSpec current] waitForExpectationsWithTimeout:1 handler:nil];
+
         [req cancel];
         });
 
@@ -115,10 +132,7 @@
 
     it(@"handles resource data", ^
         {
-        stubRequest(@"GET", @"http://example.api/foo")
-            .andReturn(200)
-            .withHeader(@"Content-type", @"application/json")
-            .withBody(@"{\"foo\": \"bar\"}");
+        [NetworkStub addForMethod:@"GET" resource:resource returningStatusCode:200 headers:@{@"Content-type": @"application/json"} body:@"{\"foo\": \"bar\"}"];
 
         XCTestExpectation *expectation = [[QuickSpec current] expectationWithDescription:@"network calls finished"];
         _ = [[resource load] onSuccess:^(BOSEntity *entity) { [expectation fulfill]; }];
@@ -144,7 +158,7 @@
 
     it(@"handles HTTP errors", ^
         {
-        stubRequest(@"GET", @"http://example.api/foo").andReturn(507);
+        [NetworkStub addForMethod:@"GET" resource:resource returningStatusCode:507];
 
         XCTestExpectation *expectation = [[QuickSpec current] expectationWithDescription:@"network calls finished"];
         _ = [[resource load] onFailure:^(BOSError *error) { [expectation fulfill]; }];
@@ -186,10 +200,7 @@
             blockObserverCalls++;
         }];
 
-        stubRequest(@"GET", @"http://example.api/foo")
-            .andReturn(200)
-            .withHeader(@"Content-type", @"application/json")
-            .withBody(@"{\"foo\": \"bar\"}");
+        [NetworkStub addForMethod:@"GET" resource:resource returningStatusCode:200 headers:@{@"Content-type": @"application/json"} body:@"{\"foo\": \"bar\"}"];
 
         XCTestExpectation *expectation = [[QuickSpec current] expectationWithDescription:@"network calls finished"];
         _ = [[resource load] onSuccess:^(BOSEntity *entity) { [expectation fulfill]; }];

--- a/Tests/Functional/PipelineSpec.swift
+++ b/Tests/Functional/PipelineSpec.swift
@@ -9,7 +9,6 @@
 import Siesta
 import Quick
 import Nimble
-import Nocilla
 
 class PipelineSpec: ResourceSpecBase
     {

--- a/Tests/Functional/ProgressSpec.swift
+++ b/Tests/Functional/ProgressSpec.swift
@@ -41,7 +41,10 @@ class ProgressSpec: ResourceSpecBase
 
             it("on connection error")
                 {
-                _ = stubRequest(resource, "GET").andFailWithError(NSError(domain: "foo", code: 1, userInfo: nil))
+                NetworkStub.add(
+                    .get, resource,
+                    returning: ErrorResponse(
+                        error: NSError(domain: "foo", code: 1, userInfo: nil)))
                 let req = resource().load()
                 awaitFailure(req)
                 expect(req.progress) == 1.0

--- a/Tests/Functional/ProgressSpec.swift
+++ b/Tests/Functional/ProgressSpec.swift
@@ -59,7 +59,6 @@ class ProgressSpec: ResourceSpecBase
                 awaitFailure(req, initialState: .completed)
 
                 _ = reqStub.go()
-                awaitCancelledRequests()
                 }
             }
 

--- a/Tests/Functional/ProgressSpec.swift
+++ b/Tests/Functional/ProgressSpec.swift
@@ -52,7 +52,7 @@ class ProgressSpec: ResourceSpecBase
 
             it("on cancellation")
                 {
-                let reqStub = stubRequest(resource, "GET").andReturn(200).delay()
+                let reqStub = NetworkStub.add(.get, resource).delay()
                 let req = resource().load()
                 req.cancel()
                 expect(req.progress) == 1.0
@@ -279,7 +279,7 @@ class ProgressSpec: ResourceSpecBase
                 let expectation = QuickSpec.current.expectation(description: "recordProgressUntil")
                 var fulfilled = false
 
-                let reqStub = stubRequest(resource, "GET").andReturn(200).delay()
+                let reqStub = NetworkStub.add(.get, resource).delay()
                 let req = resource().load().onProgress
                     {
                     progressReports.append($0)

--- a/Tests/Functional/ProgressSpec.swift
+++ b/Tests/Functional/ProgressSpec.swift
@@ -18,7 +18,7 @@ class ProgressSpec: ResourceSpecBase
             {
             it("on success")
                 {
-                _ = stubRequest(resource, "GET").andReturn(200)
+                NetworkStub.add(.get, resource)
                 let req = resource().load()
                 awaitNewData(req)
                 expect(req.progress) == 1.0
@@ -33,7 +33,7 @@ class ProgressSpec: ResourceSpecBase
 
             it("on server error")
                 {
-                _ = stubRequest(resource, "GET").andReturn(500)
+                NetworkStub.add(.get, resource, status: 500)
                 let req = resource().load()
                 awaitFailure(req)
                 expect(req.progress) == 1.0

--- a/Tests/Functional/ProgressSpec.swift
+++ b/Tests/Functional/ProgressSpec.swift
@@ -9,7 +9,6 @@
 @testable import Siesta
 import Quick
 import Nimble
-import Nocilla
 
 class ProgressSpec: ResourceSpecBase
     {

--- a/Tests/Functional/RemoteImageViewSpec.swift
+++ b/Tests/Functional/RemoteImageViewSpec.swift
@@ -11,7 +11,6 @@ import Foundation
 import SiestaUI
 import Quick
 import Nimble
-import Nocilla
 
 class RemoteImageViewSpec: SiestaSpec
     {

--- a/Tests/Functional/RequestSpec.swift
+++ b/Tests/Functional/RequestSpec.swift
@@ -9,7 +9,6 @@
 import Siesta
 import Quick
 import Nimble
-import Nocilla
 
 class RequestSpec: ResourceSpecBase
     {
@@ -701,10 +700,6 @@ class RequestSpec: ResourceSpecBase
                     _ = reqStub.go()
                     awaitFailure(originalReq, initialState: .completed)
                     expectResult("custom", for: chainedReq, initialState: .completed)
-
-                    // For whatever reason, this spec is especially prone to hitting Nocilla’s
-                    // quirk of making cancelled requests go through anyway
-                    Thread.sleep(forTimeInterval: 0.05)
                     }
                 }
 

--- a/Tests/Functional/RequestSpec.swift
+++ b/Tests/Functional/RequestSpec.swift
@@ -65,7 +65,7 @@ class RequestSpec: ResourceSpecBase
 
                     for counter in ["malkovich", "malkovichmalkovich", "malkovichmalkovichmalkovich"]
                         {
-                        LSNocilla.sharedInstance().clearStubs()
+                        NetworkStub.clearAll()
                         NetworkStub.add(
                             matching: RequestPattern(
                                 .get, resource,
@@ -341,7 +341,7 @@ class RequestSpec: ResourceSpecBase
             {
             func stubRepeatedRequest(_ answer: String = "No.", flavorHeader: String? = nil)
                 {
-                LSNocilla.sharedInstance().clearStubs()
+                NetworkStub.clearAll()
                 NetworkStub.add(
                     matching: RequestPattern(
                         .patch, resource,
@@ -661,7 +661,7 @@ class RequestSpec: ResourceSpecBase
                 let chainedReq = originalReq.chained
                     {
                     _ in
-                    LSNocilla.sharedInstance().clearStubs()
+                    NetworkStub.clearAll()
                     stubText("yoyo")
                     return .passTo(originalReq.repeated())
                     }

--- a/Tests/Functional/RequestSpec.swift
+++ b/Tests/Functional/RequestSpec.swift
@@ -88,7 +88,7 @@ class RequestSpec: ResourceSpecBase
 
                     _ = stubRequest(resource, "POST")
                         .withHeader("Content-Length", "4")
-                        .withBody(Data([0, 1, 2, 42]) as NSData)
+                        .withBody(Data([0, 1, 2, 42]))
                         .andReturn(200)
                     awaitNewData(resource().request(.post, data: Data([0, 1, 2]), contentType: "foo/bar"))
                     }
@@ -253,7 +253,7 @@ class RequestSpec: ResourceSpecBase
 
                         _ = stubRequest(resource, "GET").andReturn(200)
                             .withHeader("Content-Type", "text/plain")
-                            .withBody("ducks" as NSString)
+                            .withBody("ducks")
                         awaitNewData(resource().load())
                         expect(resource().text) == "ducks redux"
                         }
@@ -332,11 +332,11 @@ class RequestSpec: ResourceSpecBase
                 {
                 LSNocilla.sharedInstance().clearStubs()
                 _ = stubRequest(resource, "PATCH")
-                    .withBody("Is there an echo in here?" as NSString)
+                    .withBody("Is there an echo in here?")
                     .withHeader("X-Flavor", flavorHeader)
                     .andReturn(200)
                     .withHeader("Content-Type", "text/plain")
-                    .withBody(answer as NSString)
+                    .withBody(answer)
                 }
 
             func expectResonseText(_ request: Request, text: String)
@@ -454,7 +454,7 @@ class RequestSpec: ResourceSpecBase
 
                 _ = stubRequest(resource, "POST")
                     .withHeader("Content-Type", "application/monkey")
-                    .withBody(nsdata as NSData)
+                    .withBody(nsdata)
                     .andReturn(200)
 
                 awaitNewData(resource().request(.post, data: nsdata, contentType: "application/monkey"))
@@ -464,7 +464,7 @@ class RequestSpec: ResourceSpecBase
                 {
                 _ = stubRequest(resource, "POST")
                     .withHeader("Content-Type", "text/plain; charset=utf-8")
-                    .withBody("Très bien!" as NSString)
+                    .withBody("Très bien!")
                     .andReturn(200)
 
                 awaitNewData(resource().request(.post, text: "Très bien!"))
@@ -486,7 +486,7 @@ class RequestSpec: ResourceSpecBase
                 {
                 _ = stubRequest(resource, "PUT")
                     .withHeader("Content-Type", "application/json")
-                    .withBody("{\"question\":[[2,\"be\"],[\"not\",2,\"be\"]]}" as NSString)
+                    .withBody("{\"question\":[[2,\"be\"],[\"not\",2,\"be\"]]}")
                     .andReturn(200)
 
                 awaitNewData(resource().request(.put, json: ["question": [[2, "be"], ["not", 2, "be"]]]))
@@ -506,7 +506,7 @@ class RequestSpec: ResourceSpecBase
                     {
                     _ = stubRequest(resource, "PATCH")
                         .withHeader("Content-Type", "application/x-www-form-urlencoded")
-                        .withBody("brown=cow&foo=bar&how=now" as NSString)
+                        .withBody("brown=cow&foo=bar&how=now")
                         .andReturn(200)
 
                     awaitNewData(resource().request(.patch, urlEncoded: ["foo": "bar", "how": "now", "brown": "cow"]))
@@ -516,7 +516,7 @@ class RequestSpec: ResourceSpecBase
                     {
                     _ = stubRequest(resource, "PATCH")
                         .withHeader("Content-Type", "application/x-www-form-urlencoded")
-                        .withBody("%E2%84%A5%3D%26=%E2%84%8C%E2%84%91%3D%26&f%E2%80%A2%E2%80%A2=b%20r" as NSString)
+                        .withBody("%E2%84%A5%3D%26=%E2%84%8C%E2%84%91%3D%26&f%E2%80%A2%E2%80%A2=b%20r")
                         .andReturn(200)
 
                     awaitNewData(resource().request(.patch, urlEncoded: ["f••": "b r", "℥=&": "ℌℑ=&"]))
@@ -580,7 +580,7 @@ class RequestSpec: ResourceSpecBase
                 {
                 return stubRequest(resource, method).andReturn(200)
                     .withHeader("Content-Type", "text/plain")
-                    .withBody(body as NSString)
+                    .withBody(body)
                 }
 
             func expectResult(_ expectedResult: String, for req: Request, initialState: RequestState = .inProgress)

--- a/Tests/Functional/RequestSpec.swift
+++ b/Tests/Functional/RequestSpec.swift
@@ -18,13 +18,13 @@ class RequestSpec: ResourceSpecBase
             {
             it("initates a network call")
                 {
-                _ = stubRequest(resource, "GET").andReturn(200)
+                NetworkStub.add(.get, resource)
                 awaitNewData(resource().request(.get))
                 }
 
             it("handles various HTTP methods")
                 {
-                _ = stubRequest(resource, "PATCH").andReturn(200)
+                NetworkStub.add(.patch, resource)
                 awaitNewData(resource().request(.patch))
                 }
 
@@ -32,7 +32,7 @@ class RequestSpec: ResourceSpecBase
                 {
                 it("represents response without body as zero-length Data for \(method) → \(httpCode)")
                     {
-                    _ = stubRequest(resource, "HEAD").andReturn(200)
+                    NetworkStub.add(.head, resource)
                     let req = resource().request(.head)
                     awaitNewData(req)
                     req.onSuccess { expect($0.typedContent()) == Data() }
@@ -142,8 +142,8 @@ class RequestSpec: ResourceSpecBase
                             }
                         }
 
-                    _ = stubRequest(resource, "GET").andReturn(200)
-                    _ = stubRequest(resource, "POST").andReturn(200)
+                    NetworkStub.add(.get, resource)
+                    NetworkStub.add(.post, resource)
                     awaitNewData(resource().load())
                     awaitNewData(resource().request(.post))
 
@@ -159,7 +159,7 @@ class RequestSpec: ResourceSpecBase
                             { $1.onSuccess { _ in successHookCalled = true } }
                         }
 
-                    _ = stubRequest(resource, "GET").andReturn(200)
+                    NetworkStub.add(.get, resource)
                     awaitNewData(resource().load())
 
                     expect(successHookCalled) == true
@@ -280,7 +280,7 @@ class RequestSpec: ResourceSpecBase
                     it("runs the original request if it is deferred but used by a chain")
                         {
                         configureDeferredRequestChain(passToOriginalRequest: true)
-                        _ = stubRequest(resource, "GET").andReturn(200)
+                        NetworkStub.add(.get, resource)
                         awaitNewData(resource().load())
                         }
 
@@ -308,7 +308,7 @@ class RequestSpec: ResourceSpecBase
 
         it(".cancel() has no effect if it already succeeded")
             {
-            _ = stubRequest(resource, "GET").andReturn(200)
+            NetworkStub.add(.get, resource)
             let req = resource().request(.get)
             req.onCompletion
                 { expect($0.response.isCancellation) == false }

--- a/Tests/Functional/RequestSpec.swift
+++ b/Tests/Functional/RequestSpec.swift
@@ -185,7 +185,7 @@ class RequestSpec: ResourceSpecBase
                             }
                         }
 
-                    awaitFailure(resource().load(), initialState: .completed)  // Nocilla will flag if network call goes through
+                    awaitFailure(resource().load(), initialState: .completed)  // NetworkStub will flag if network call goes through
                     }
 
                 context("substituting a request")
@@ -239,7 +239,7 @@ class RequestSpec: ResourceSpecBase
                             $0.decorateRequests
                                 { _,_  in dummyReq0() }
                             }
-                        awaitFailure(resource().load(), initialState: .completed)  // Nocilla will flag if network call goes through
+                        awaitFailure(resource().load(), initialState: .completed)  // NetworkStub will flag if network call goes through
                         }
 
                     it("starts the original request if it is the first in a chain")

--- a/Tests/Functional/RequestSpec.swift
+++ b/Tests/Functional/RequestSpec.swift
@@ -251,9 +251,11 @@ class RequestSpec: ResourceSpecBase
                                 }
                             }
 
-                        _ = stubRequest(resource, "GET").andReturn(200)
-                            .withHeader("Content-Type", "text/plain")
-                            .withBody("ducks")
+                        NetworkStub.add(
+                            .get, resource,
+                            returning: HTTPResponse(
+                                headers: ["Content-Type": "text/plain"],
+                                body: "ducks"))
                         awaitNewData(resource().load())
                         expect(resource().text) == "ducks redux"
                         }

--- a/Tests/Functional/ResourceObserversSpec.swift
+++ b/Tests/Functional/ResourceObserversSpec.swift
@@ -9,7 +9,6 @@
 import Siesta
 import Quick
 import Nimble
-import Nocilla
 
 class ResourceObserversSpec: ResourceSpecBase
     {

--- a/Tests/Functional/ResourceObserversSpec.swift
+++ b/Tests/Functional/ResourceObserversSpec.swift
@@ -181,8 +181,8 @@ class ResourceObserversSpec: ResourceSpecBase
 
             it("receives cancel event")
                 {
-                // delay prevents race condition between cancel() and Nocilla
-                let reqStub = stubRequest(resource, "GET").andReturn(200).delay()
+                // delay prevents race condition between cancel() and network response
+                let reqStub = NetworkStub.add(.get, resource).delay()
                 observer.expect(.requested)
                 observer.expect(.requestCancelled)
                     {
@@ -418,7 +418,7 @@ class ResourceObserversSpec: ResourceSpecBase
 
                 // Start request; observer should hear about it
 
-                let reqStub = stubRequest(resource, "GET").andReturn(200).delay()
+                let reqStub = NetworkStub.add(.get, resource).delay()
                 let req = resource().load()
                 observer().checkForUnfulfilledExpectations()
 

--- a/Tests/Functional/ResourceObserversSpec.swift
+++ b/Tests/Functional/ResourceObserversSpec.swift
@@ -159,7 +159,7 @@ class ResourceObserversSpec: ResourceSpecBase
                 observer.expect(.requested)
                 observer.expect(.newData(.network))
                 awaitNewData(resource().load())
-                LSNocilla.sharedInstance().clearStubs()
+                NetworkStub.clearAll()
 
                 NetworkStub.add(.get, resource, status: 304)
                 observer.expect(.requested)

--- a/Tests/Functional/ResourceObserversSpec.swift
+++ b/Tests/Functional/ResourceObserversSpec.swift
@@ -112,7 +112,7 @@ class ResourceObserversSpec: ResourceSpecBase
 
             it("receives request event")
                 {
-                _ = stubRequest(resource, "GET").andReturn(200)
+                NetworkStub.add(.get, resource)
                 observer.expect(.requested)
                     {
                     expect(resource().isLoading) == true
@@ -129,7 +129,7 @@ class ResourceObserversSpec: ResourceSpecBase
 
             it("receives new data event")
                 {
-                _ = stubRequest(resource, "GET").andReturn(200)
+                NetworkStub.add(.get, resource)
                 observer.expect(.requested)
                 observer.expect(.newData(.network))
                     {
@@ -155,13 +155,13 @@ class ResourceObserversSpec: ResourceSpecBase
 
             it("receives not modified event")
                 {
-                _ = stubRequest(resource, "GET").andReturn(200)
+                NetworkStub.add(.get, resource)
                 observer.expect(.requested)
                 observer.expect(.newData(.network))
                 awaitNewData(resource().load())
                 LSNocilla.sharedInstance().clearStubs()
 
-                _ = stubRequest(resource, "GET").andReturn(304)
+                NetworkStub.add(.get, resource, status: 304)
                 observer.expect(.requested)
                 observer.expect(.notModified)
                     {
@@ -172,7 +172,7 @@ class ResourceObserversSpec: ResourceSpecBase
 
             it("receives error if server sends not modified but no local data")
                 {
-                _ = stubRequest(resource, "GET").andReturn(304)
+                NetworkStub.add(.get, resource, status: 304)
                 observer.expect(.requested)
                 observer.expect(.error)
                 awaitFailure(resource().load())
@@ -198,7 +198,7 @@ class ResourceObserversSpec: ResourceSpecBase
 
             it("receives failure event")
                 {
-                _ = stubRequest(resource, "GET").andReturn(500)
+                NetworkStub.add(.get, resource, status: 500)
                 observer.expect(.requested)
                 observer.expect(.error)
                     {
@@ -211,7 +211,7 @@ class ResourceObserversSpec: ResourceSpecBase
 
             it("does not receive notifications for request(), only load()")
                 {
-                _ = stubRequest(resource, "GET").andReturn(200)
+                NetworkStub.add(.get, resource)
                 awaitNewData(resource().request(.get))
                 }
 
@@ -228,7 +228,7 @@ class ResourceObserversSpec: ResourceSpecBase
                     events.append(String(describing: event))
                     }
 
-                _ = stubRequest(resource, "GET").andReturn(200)
+                NetworkStub.add(.get, resource)
                 awaitNewData(resource().load())
 
                 expect(events) == ["observerAdded", "requested", "newData(network)"]
@@ -247,7 +247,7 @@ class ResourceObserversSpec: ResourceSpecBase
                 resource().addObserver(owner: dummy)
                     { _, event in events0.append(String(describing: event)) }
 
-                _ = stubRequest(resource, "GET").andReturn(200)
+                NetworkStub.add(.get, resource)
                 awaitNewData(resource().load())
 
                 resource().addObserver(owner: dummy)
@@ -266,7 +266,7 @@ class ResourceObserversSpec: ResourceSpecBase
                 resource().addObserver(observer)
                 resource().addObserver(observer)
 
-                _ = stubRequest(resource, "GET").andReturn(200)
+                NetworkStub.add(.get, resource)
                 observer.expect(.requested)
                 observer.expect(.newData(.network))
                 awaitNewData(resource().load())
@@ -291,7 +291,7 @@ class ResourceObserversSpec: ResourceSpecBase
 
                 func expectStillObserving(_ stillObserving: Bool)
                     {
-                    _ = stubRequest(resource, "GET").andReturn(200)
+                    NetworkStub.add(.get, resource)
                     if stillObserving
                         {
                         observer.expect(.requested)

--- a/Tests/Functional/ResourceObserversSpec.swift
+++ b/Tests/Functional/ResourceObserversSpec.swift
@@ -121,7 +121,7 @@ class ResourceObserversSpec: ResourceSpecBase
                     }
                 let req = resource().load()
 
-                // Let Nocilla check off request without any further observing
+                // Let request finish without any further observing
                 observer.expectStoppedObserving()
                 resource().removeObservers(ownedBy: observer)
                 awaitNewData(req)
@@ -192,8 +192,6 @@ class ResourceObserversSpec: ResourceSpecBase
                 req.cancel()
                 _ = reqStub.go()
                 awaitFailure(req, initialState: .completed)
-
-                awaitCancelledRequests()
                 }
 
             it("receives failure event")

--- a/Tests/Functional/ResourcePathsSpec.swift
+++ b/Tests/Functional/ResourcePathsSpec.swift
@@ -9,7 +9,6 @@
 import Siesta
 import Quick
 import Nimble
-import Nocilla
 
 class ResourcePathsSpec: ResourceSpecBase
     {

--- a/Tests/Functional/ResourceSpecBase.swift
+++ b/Tests/Functional/ResourceSpecBase.swift
@@ -58,7 +58,10 @@ class ResourceSpecBase: SiestaSpec
                     delegate: nil,
                     delegateQueue: backgroundQueue)
                 }())
-            runSpecsWithNetworkingProvider("Alamofire networking", networking: Alamofire.SessionManager.default)
+            runSpecsWithNetworkingProvider("Alamofire networking", networking:
+                Alamofire.SessionManager(
+                    configuration: NetworkStub.wrap(
+                        Alamofire.SessionManager.default.session.configuration)))
             }
         else
             { runSpecsWithDefaultProvider() }

--- a/Tests/Functional/ResourceSpecBase.swift
+++ b/Tests/Functional/ResourceSpecBase.swift
@@ -235,7 +235,9 @@ private func pollUnderlyingCompletion(_ req: Siesta.Request, expectation: XCTest
 
 func stubAndAwaitRequest(for resource: Resource, expectSuccess: Bool = true)
     {
-    _ = stubRequest({ resource }, "GET").andReturn(200).withBody("🍕")
+    NetworkStub.add(
+        .get, { resource },
+        returning: HTTPResponse(body: "🍕"))
     let awaitRequest = expectSuccess ? awaitNewData : awaitFailure
     awaitRequest(resource.load(), .inProgress)
     }

--- a/Tests/Functional/ResourceSpecBase.swift
+++ b/Tests/Functional/ResourceSpecBase.swift
@@ -172,7 +172,7 @@ func stubRequest(_ resource: () -> Resource, _ method: String) -> LSStubRequestD
 @discardableResult
 func stubRequest(_ resource: Resource, _ method: String) -> LSStubRequestDSL
     {
-    stubRequest(method, resource.url.absoluteString as NSString)
+    stubRequest(method, resource.url.absoluteString)
     }
 
 func awaitNewData(_ req: Siesta.Request, initialState: RequestState = .inProgress)
@@ -247,7 +247,7 @@ private func pollUnderlyingCompletion(_ req: Siesta.Request, expectation: XCTest
 
 func stubAndAwaitRequest(for resource: Resource, expectSuccess: Bool = true)
     {
-    _ = stubRequest(resource, "GET").andReturn(200).withBody("🍕" as NSString)
+    _ = stubRequest(resource, "GET").andReturn(200).withBody("🍕")
     let awaitRequest = expectSuccess ? awaitNewData : awaitFailure
     awaitRequest(resource.load(), .inProgress)
     }

--- a/Tests/Functional/ResourceSpecBase.swift
+++ b/Tests/Functional/ResourceSpecBase.swift
@@ -37,12 +37,6 @@ class ResourceSpecBase: SiestaSpec
         {
         super.spec()
 
-        func envFlag(_ key: String) -> Bool
-            {
-            let value = ProcessInfo.processInfo.environment["Siesta_\(key)"] ?? ""
-            return value == "1" || value == "true"
-            }
-
         beforeEach { NetworkStub.clearAll() }
 
         let realNow = Siesta.now
@@ -52,7 +46,7 @@ class ResourceSpecBase: SiestaSpec
             }
         afterEach { fakeNow = nil }
 
-        if envFlag("TestMultipleNetworkProviders")
+        if SiestaSpec.envFlag("TestMultipleNetworkProviders")
             {
             runSpecsWithNetworkingProvider("default URLSession",   networking: NetworkStub.wrap(URLSessionConfiguration.default))
             runSpecsWithNetworkingProvider("ephemeral URLSession", networking: NetworkStub.wrap(URLSessionConfiguration.ephemeral))

--- a/Tests/Functional/ResourceSpecBase.swift
+++ b/Tests/Functional/ResourceSpecBase.swift
@@ -161,19 +161,7 @@ class ResourceSpecBase: SiestaSpec
     }
 
 
-// MARK: - Request stubbing
-
-@discardableResult
-func stubRequest(_ resource: () -> Resource, _ method: String) -> LSStubRequestDSL
-    {
-    stubRequest(resource(), method)
-    }
-
-@discardableResult
-func stubRequest(_ resource: Resource, _ method: String) -> LSStubRequestDSL
-    {
-    stubRequest(method, resource.url.absoluteString)
-    }
+// MARK: - Awaiting requests
 
 func awaitNewData(_ req: Siesta.Request, initialState: RequestState = .inProgress)
     {
@@ -247,7 +235,7 @@ private func pollUnderlyingCompletion(_ req: Siesta.Request, expectation: XCTest
 
 func stubAndAwaitRequest(for resource: Resource, expectSuccess: Bool = true)
     {
-    _ = stubRequest(resource, "GET").andReturn(200).withBody("🍕")
+    _ = stubRequest({ resource }, "GET").andReturn(200).withBody("🍕")
     let awaitRequest = expectSuccess ? awaitNewData : awaitFailure
     awaitRequest(resource.load(), .inProgress)
     }

--- a/Tests/Functional/ResourceStateSpec.swift
+++ b/Tests/Functional/ResourceStateSpec.swift
@@ -171,11 +171,15 @@ class ResourceStateSpec: ResourceSpecBase
 
             func sendAndWaitForSuccessfulRequest()
                 {
-                _ = stubRequest(resource, "GET")
-                    .andReturn(200)
-                    .withHeader("eTaG", "123 456 xyz")
-                    .withHeader("Content-Type", "applicaiton/zoogle+plotz")
-                    .withBody("zoogleplotz")
+                NetworkStub.add(
+                    .get, resource,
+                    returning: HTTPResponse(
+                        headers:
+                            [
+                            "eTaG": "123 456 xyz",
+                            "Content-Type": "applicaiton/zoogle+plotz"
+                            ],
+                        body: "zoogleplotz"))
 
                 awaitNewData(resource().load())
                 LSNocilla.sharedInstance().clearStubs()
@@ -207,11 +211,15 @@ class ResourceStateSpec: ResourceSpecBase
 
                 it("handles subsequent 200 by replacing data")
                     {
-                    _ = stubRequest(resource, "GET")
-                        .andReturn(200)
-                        .withHeader("eTaG", "ABC DEF 789")
-                        .withHeader("Content-Type", "applicaiton/ploogle+zotz")
-                        .withBody("plooglezotz")
+                    NetworkStub.add(
+                        .get, resource,
+                        returning: HTTPResponse(
+                            headers:
+                                [
+                                "eTaG": "ABC DEF 789",
+                                "Content-Type": "applicaiton/ploogle+zotz"
+                                ],
+                            body: "plooglezotz"))
                     awaitNewData(resource().load())
 
                     expect(dataAsString(resource().latestData?.content)) == "plooglezotz"
@@ -256,7 +264,7 @@ class ResourceStateSpec: ResourceSpecBase
                 {
                 it("treats HTTP \(statusCode) as an error")
                     {
-                    _ = stubRequest(resource, "GET").andReturn(statusCode)
+                    NetworkStub.add(.get, resource, status: statusCode)
                     awaitFailure(resource().load())
 
                     expect(resource().latestData).to(beNil())
@@ -424,10 +432,11 @@ class ResourceStateSpec: ResourceSpecBase
 
             beforeEach
                 {
-                _ = stubRequest(resource, "POST")
-                    .andReturn(200)
-                    .withHeader("Content-type", "text/plain")
-                    .withBody("Posted!")
+                NetworkStub.add(
+                    .post, resource,
+                    returning: HTTPResponse(
+                        headers: ["Content-type": "text/plain"],
+                        body: "Posted!"))
                 }
 
             it("updates resource state")
@@ -589,11 +598,15 @@ class ResourceStateSpec: ResourceSpecBase
             {
             it("updates latestData’s content without altering headers")
                 {
-                _ = stubRequest(resource, "GET")
-                    .andReturn(200)
-                    .withHeader("Content-type", "food/pasta")
-                    .withHeader("Sauce-disposition", "garlic")
-                    .withBody("linguine")
+                NetworkStub.add(
+                    .get, resource,
+                    returning: HTTPResponse(
+                        headers:
+                            [
+                            "Content-type": "food/pasta",
+                            "Sauce-disposition": "garlic"
+                            ],
+                        body: "linguine"))
 
                 awaitNewData(resource().load())
 

--- a/Tests/Functional/ResourceStateSpec.swift
+++ b/Tests/Functional/ResourceStateSpec.swift
@@ -87,7 +87,7 @@ class ResourceStateSpec: ResourceSpecBase
             it("stores the response data")
                 {
                 _ = stubRequest(resource, "GET").andReturn(200)
-                    .withBody("eep eep" as NSString)
+                    .withBody("eep eep")
                 awaitNewData(resource().load())
 
                 expect(resource().latestData).notTo(beNil())
@@ -169,7 +169,7 @@ class ResourceStateSpec: ResourceSpecBase
                     .andReturn(200)
                     .withHeader("eTaG", "123 456 xyz")
                     .withHeader("Content-Type", "applicaiton/zoogle+plotz")
-                    .withBody("zoogleplotz" as NSString)
+                    .withBody("zoogleplotz")
                 awaitNewData(resource().load())
                 LSNocilla.sharedInstance().clearStubs()
                 }
@@ -204,7 +204,7 @@ class ResourceStateSpec: ResourceSpecBase
                         .andReturn(200)
                         .withHeader("eTaG", "ABC DEF 789")
                         .withHeader("Content-Type", "applicaiton/ploogle+zotz")
-                        .withBody("plooglezotz" as NSString)
+                        .withBody("plooglezotz")
                     awaitNewData(resource().load())
 
                     expect(dataAsString(resource().latestData?.content)) == "plooglezotz"
@@ -414,7 +414,7 @@ class ResourceStateSpec: ResourceSpecBase
                 _ = stubRequest(resource, "POST")
                     .andReturn(200)
                     .withHeader("Content-type", "text/plain")
-                    .withBody("Posted!" as NSString)
+                    .withBody("Posted!")
                 }
 
             it("updates resource state")
@@ -580,7 +580,7 @@ class ResourceStateSpec: ResourceSpecBase
                     .andReturn(200)
                     .withHeader("Content-type", "food/pasta")
                     .withHeader("Sauce-disposition", "garlic")
-                    .withBody("linguine" as NSString)
+                    .withBody("linguine")
 
                 awaitNewData(resource().load())
 
@@ -593,7 +593,7 @@ class ResourceStateSpec: ResourceSpecBase
             it("updates latestData’s timestamp")
                 {
                 setResourceTime(1000)
-                _ = stubRequest(resource, "GET").andReturn(200).withBody("hello" as NSString)
+                _ = stubRequest(resource, "GET").andReturn(200).withBody("hello")
                 awaitNewData(resource().load())
 
                 setResourceTime(2000)

--- a/Tests/Functional/ResourceStateSpec.swift
+++ b/Tests/Functional/ResourceStateSpec.swift
@@ -9,7 +9,6 @@
 import Siesta
 import Quick
 import Nimble
-import Nocilla
 
 class ResourceStateSpec: ResourceSpecBase
     {

--- a/Tests/Functional/ResourceStateSpec.swift
+++ b/Tests/Functional/ResourceStateSpec.swift
@@ -184,7 +184,7 @@ class ResourceStateSpec: ResourceSpecBase
                         body: "zoogleplotz"))
 
                 awaitNewData(resource().load())
-                LSNocilla.sharedInstance().clearStubs()
+                NetworkStub.clearAll()
                 }
 
             func expectDataToBeUnchanged()
@@ -406,7 +406,7 @@ class ResourceStateSpec: ResourceSpecBase
                     setResourceTime(1000)
                     NetworkStub.add(.get, resource, status: 404)
                     awaitFailure(resource().load())
-                    LSNocilla.sharedInstance().clearStubs()
+                    NetworkStub.clearAll()
                     }
 
                 it("does not retry soon")
@@ -653,12 +653,12 @@ class ResourceStateSpec: ResourceSpecBase
                 setResourceTime(dataTimestamp)
                 NetworkStub.add(.get, resource)
                 awaitNewData(resource().load())
-                LSNocilla.sharedInstance().clearStubs()
+                NetworkStub.clearAll()
 
                 setResourceTime(errorTimestamp)
                 NetworkStub.add(.get, resource, status: 500)
                 awaitFailure(resource().load())
-                LSNocilla.sharedInstance().clearStubs()
+                NetworkStub.clearAll()
                 }
 
             it("does not trigger an immediate request")
@@ -683,7 +683,7 @@ class ResourceStateSpec: ResourceSpecBase
 
                 afterEach
                     {
-                    LSNocilla.sharedInstance().clearStubs()
+                    NetworkStub.clearAll()
                     let req = resource().loadIfNeeded()
                     expect(req).to(beNil())
                     }

--- a/Tests/Functional/ResourceStateSpec.swift
+++ b/Tests/Functional/ResourceStateSpec.swift
@@ -86,8 +86,9 @@ class ResourceStateSpec: ResourceSpecBase
 
             it("stores the response data")
                 {
-                _ = stubRequest(resource, "GET").andReturn(200)
-                    .withBody("eep eep")
+                NetworkStub.add(
+                    .get, resource,
+                    returning: HTTPResponse(body: "eep eep"))
                 awaitNewData(resource().load())
 
                 expect(resource().latestData).notTo(beNil())
@@ -96,8 +97,9 @@ class ResourceStateSpec: ResourceSpecBase
 
             it("stores the content type")
                 {
-                _ = stubRequest(resource, "GET").andReturn(200)
-                    .withHeader("cOnTeNt-TyPe", "text/monkey")
+                NetworkStub.add(
+                    .get, resource,
+                    returning: HTTPResponse(headers: ["cOnTeNt-TyPe": "text/monkey"]))
                 awaitNewData(resource().load())
 
                 expect(resource().latestData?.contentType) == "text/monkey"
@@ -105,8 +107,9 @@ class ResourceStateSpec: ResourceSpecBase
 
             it("extracts the charset if present")
                 {
-                _ = stubRequest(resource, "GET").andReturn(200)
-                    .withHeader("Content-type", "text/monkey; charset=utf-8")
+                NetworkStub.add(
+                    .get, resource,
+                    returning: HTTPResponse(headers: ["Content-type": "text/monkey; charset=utf-8"]))
                 awaitNewData(resource().load())
 
                 expect(resource().latestData?.charset) == "utf-8"
@@ -114,8 +117,9 @@ class ResourceStateSpec: ResourceSpecBase
 
             it("includes the charset in the content type")
                 {
-                _ = stubRequest(resource, "GET").andReturn(200)
-                    .withHeader("Content-type", "text/monkey; charset=utf-8")
+                NetworkStub.add(
+                    .get, resource,
+                    returning: HTTPResponse(headers: ["Content-type": "text/monkey; charset=utf-8"]))
                 awaitNewData(resource().load())
 
                 expect(resource().latestData?.contentType) == "text/monkey; charset=utf-8"
@@ -124,8 +128,9 @@ class ResourceStateSpec: ResourceSpecBase
             it("parses the charset")
                 {
                 let monkeyType = "text/monkey; body=fuzzy; charset=euc-jp; arms=long"
-                _ = stubRequest(resource, "GET").andReturn(200)
-                    .withHeader("Content-type", monkeyType)
+                NetworkStub.add(
+                    .get, resource,
+                    returning: HTTPResponse(headers: ["Content-type": monkeyType]))
                 awaitNewData(resource().load())
 
                 expect(resource().latestData?.contentType) == monkeyType
@@ -146,8 +151,9 @@ class ResourceStateSpec: ResourceSpecBase
 
             it("stores headers")
                 {
-                _ = stubRequest(resource, "GET").andReturn(200)
-                    .withHeader("Personal-Disposition", "Quirky")
+                NetworkStub.add(
+                    .get, resource,
+                    returning: HTTPResponse(headers: ["Personal-Disposition": "Quirky"]))
                 awaitNewData(resource().load())
 
                 expect(resource().latestData?.header(forKey: "Personal-Disposition")) == "Quirky"
@@ -594,7 +600,9 @@ class ResourceStateSpec: ResourceSpecBase
             it("updates latestData’s timestamp")
                 {
                 setResourceTime(1000)
-                _ = stubRequest(resource, "GET").andReturn(200).withBody("hello")
+                NetworkStub.add(
+                    .get, resource,
+                    returning: HTTPResponse(body: "hello"))
                 awaitNewData(resource().load())
 
                 setResourceTime(2000)

--- a/Tests/Functional/ResourceStateSpec.swift
+++ b/Tests/Functional/ResourceStateSpec.swift
@@ -489,8 +489,6 @@ class ResourceStateSpec: ResourceSpecBase
 
                 _ = reqStub().go()
                 awaitFailure(req(), initialState: .completed)
-
-                awaitCancelledRequests()
                 }
 
             it("does not cancel if resource has an observer")
@@ -794,8 +792,6 @@ class ResourceStateSpec: ResourceSpecBase
                 expect(resource().isLoading) == false
                 expect(resource().latestData).to(beNil())
                 expect(resource().latestError).to(beNil())
-
-                awaitCancelledRequests()
                 }
 
             it("cancels requests attached with load(using:) even if they came from another resource")

--- a/Tests/Functional/ResourceStateSpec.swift
+++ b/Tests/Functional/ResourceStateSpec.swift
@@ -203,9 +203,11 @@ class ResourceStateSpec: ResourceSpecBase
 
                 it("sends the etag with subsequent requests")
                     {
-                    _ = stubRequest(resource, "GET")
-                        .withHeader("If-None-Match", "123 456 xyz")
-                        .andReturn(304)
+                    NetworkStub.add(
+                        matching: RequestPattern(
+                            .get, resource,
+                            headers: ["If-None-Match": "123 456 xyz"]),
+                        returning: HTTPResponse(status: 304))
                     awaitNotModified(resource().load())
                     }
 

--- a/Tests/Functional/ResponseDataHandlingSpec.swift
+++ b/Tests/Functional/ResponseDataHandlingSpec.swift
@@ -308,7 +308,7 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                 func stubMalformedResponse(contentType: String, expectSuccess: Bool)
                     {
                     let resource = service.resource(contentType)
-                    _ = stubRequest(resource, "GET").andReturn(200)
+                    _ = stubRequest({ resource }, "GET").andReturn(200)
                         .withHeader("Content-Type", contentType)
                         .withBody(Data([0xD8]))
                     let awaitRequest = expectSuccess ? awaitNewData : awaitFailure

--- a/Tests/Functional/ResponseDataHandlingSpec.swift
+++ b/Tests/Functional/ResponseDataHandlingSpec.swift
@@ -125,7 +125,7 @@ class ResponseDataHandlingSpec: ResourceSpecBase
 
                 it("gives empty string on error")
                     {
-                    _ = stubRequest(resource, "GET").andReturn(404)
+                    NetworkStub.add(.get, resource, status: 404)
                     expect(resource().text) == ""
                     }
                 }
@@ -240,7 +240,7 @@ class ResponseDataHandlingSpec: ResourceSpecBase
 
                 it("gives empty dict on error")
                     {
-                    _ = stubRequest(resource, "GET").andReturn(500)
+                    NetworkStub.add(.get, resource, status: 500)
                     expect(resource().jsonDict as NSObject) == [:] as NSObject
                     }
                 }
@@ -377,7 +377,7 @@ class ResponseDataHandlingSpec: ResourceSpecBase
 
                 it("can transform errors")
                     {
-                    _ = stubRequest(resource, "GET").andReturn(401)
+                    NetworkStub.add(.get, resource, status: 401)
                     awaitFailure(resource().load())
                     expect(resource().latestError?.userMessage) == "Unauthorized processed"
                     expect(transformer().callCount) == 1
@@ -388,7 +388,7 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                     stubText("ahoy")
 
                     LSNocilla.sharedInstance().clearStubs()
-                    _ = stubRequest(resource, "GET").andReturn(304)
+                    NetworkStub.add(.get, resource, status: 304)
                     awaitNotModified(resource().load())
 
                     expect(resource().typedContent()) == "ahoy processed"

--- a/Tests/Functional/ResponseDataHandlingSpec.swift
+++ b/Tests/Functional/ResponseDataHandlingSpec.swift
@@ -9,7 +9,6 @@
 import Siesta
 import Quick
 import Nimble
-import Nocilla
 
 class ResponseDataHandlingSpec: ResourceSpecBase
     {
@@ -303,7 +302,7 @@ class ResponseDataHandlingSpec: ResourceSpecBase
 
         describe("standard transformers")
             {
-            let url = "https://pars.ing"
+            let url = "test://pars.ing"
 
             func checkStandardParsing(for service: Service, json: Bool, text: Bool, images: Bool)
                 {
@@ -326,26 +325,26 @@ class ResponseDataHandlingSpec: ResourceSpecBase
             it("include JSON, text, and images by default")
                 {
                 checkStandardParsing(
-                    for: Service(baseURL: url),
+                    for: Service(baseURL: url, networking: NetworkStub.defaultConfiguration),
                     json: true, text: true, images: true)
                 }
 
             it("can be selectively disabled on Service creation")
                 {
                 checkStandardParsing(
-                    for: Service(baseURL: url, standardTransformers: [.text, .image]),
+                    for: Service(baseURL: url, standardTransformers: [.text, .image], networking: NetworkStub.defaultConfiguration),
                     json: false, text: true, images: true)
                 checkStandardParsing(
-                    for: Service(baseURL: url, standardTransformers: [.json]),
+                    for: Service(baseURL: url, standardTransformers: [.json], networking: NetworkStub.defaultConfiguration),
                     json: true, text: false, images: false)
                 checkStandardParsing(
-                    for: Service(baseURL: url, standardTransformers: []),
+                    for: Service(baseURL: url, standardTransformers: [], networking: NetworkStub.defaultConfiguration),
                     json: false, text: false, images: false)
                 }
 
             it("can be cleared and re-added in configuration")
                 {
-                let service = Service(baseURL: url)
+                let service = Service(baseURL: url, networking: NetworkStub.defaultConfiguration)
                 service.configure
                     {
                     $0.pipeline.clear()

--- a/Tests/Functional/ResponseDataHandlingSpec.swift
+++ b/Tests/Functional/ResponseDataHandlingSpec.swift
@@ -413,7 +413,7 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                     {
                     stubText("ahoy")
 
-                    LSNocilla.sharedInstance().clearStubs()
+                    NetworkStub.clearAll()
                     NetworkStub.add(.get, resource, status: 304)
                     awaitNotModified(resource().load())
 

--- a/Tests/Functional/ResponseDataHandlingSpec.swift
+++ b/Tests/Functional/ResponseDataHandlingSpec.swift
@@ -23,7 +23,7 @@ class ResponseDataHandlingSpec: ResourceSpecBase
             _ = stubRequest(resource, method).andReturn(200)
                 .withHeader("Content-Type", contentType)
                 .withHeader("X-Custom-Header", "Sprotzle")
-                .withBody(string as NSString?)
+                .withBody(string)
             let awaitRequest = expectSuccess ? awaitNewData : awaitFailure
             awaitRequest(resource().load(), .inProgress)
             }
@@ -73,7 +73,7 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                 {
                 _ = stubRequest(resource, "GET").andReturn(200)
                     .withHeader("Content-Type", "text/plain; charset=utf-8")
-                    .withBody(Data([0xD8]) as NSData)
+                    .withBody(Data([0xD8]))
                 awaitFailure(resource().load())
 
                 let cause = resource().latestError?.cause as? RequestError.Cause.UndecodableText
@@ -97,7 +97,7 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                 {
                 _ = stubRequest(resource, "GET").andReturn(500)
                     .withHeader("Content-Type", "text/plain; charset=UTF-16")
-                    .withBody(Data([0xD8, 0x3D, 0xDC, 0xA3]) as NSData)
+                    .withBody(Data([0xD8, 0x3D, 0xDC, 0xA3]))
                 awaitFailure(resource().load())
                 expect(resource().latestError?.text) == "💣"
                 }
@@ -176,7 +176,7 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                     {
                     _ = stubRequest(resource, "GET").andReturn(200)
                         .withHeader("Content-Type", "application/json")
-                        .withBody(atom as NSString)
+                        .withBody(atom)
                     awaitFailure(resource().load())
 
                     expect(resource().latestError?.cause is RequestError.Cause.JSONResponseIsNotDictionaryOrArray) == true
@@ -195,7 +195,7 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                     {
                     _ = stubRequest(resource, "GET").andReturn(200)
                         .withHeader("Content-Type", "application/json")
-                        .withBody(atom as NSString)
+                        .withBody(atom)
                     awaitNewData(resource().load())
                     expect(resource().latestData?.content as? T) == expectedValue
                     }
@@ -208,7 +208,7 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                 {
                 _ = stubRequest(resource, "GET").andReturn(500)
                     .withHeader("Content-Type", "application/json")
-                    .withBody("{ \"error\": \"pigeon drove bus\" }" as NSString)
+                    .withBody("{ \"error\": \"pigeon drove bus\" }")
                 awaitFailure(resource().load())
                 expect(resource().latestError?.jsonDict as? [String:String])
                      == ["error": "pigeon drove bus"]
@@ -218,7 +218,7 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                 {
                 _ = stubRequest(resource, "GET").andReturn(500)
                     .withHeader("Content-Type", "application/json")
-                    .withBody("{ malformed JSON[[{{#$!@" as NSString)
+                    .withBody("{ malformed JSON[[{{#$!@")
                 awaitFailure(resource().load())
                 expect(resource().latestError?.userMessage) == "Internal server error"
                 expect(resource().latestError?.entity?.content as? Data).notTo(beNil())
@@ -251,7 +251,7 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                     {
                     _ = stubRequest(resource, "GET").andReturn(200)
                         .withHeader("Content-Type", "application/json")
-                        .withBody("[1,\"two\"]" as NSString)
+                        .withBody("[1,\"two\"]")
                     awaitNewData(resource().load())
                     expect(resource().jsonArray as NSObject) == [1,"two"] as NSObject
                     }
@@ -280,9 +280,8 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                 {
                 _ = stubRequest(resource, "GET").andReturn(200)
                     .withHeader("Content-Type", "image/gif")
-                    .withBody(NSData(
-                        base64Encoded: "R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=",
-                        options: [])!)
+                    .withBody(Data(
+                        base64Encoded: "R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs=")!)
                 awaitNewData(resource().load())
                 let image: Image? = resource().typedContent()
                 expect(image).notTo(beNil())
@@ -293,7 +292,7 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                 {
                 _ = stubRequest(resource, "GET").andReturn(200)
                     .withHeader("Content-Type", "image/gif")
-                    .withBody("Ceci n’est pas une image" as NSString)
+                    .withBody("Ceci n’est pas une image")
                 awaitFailure(resource().load())
 
                 expect(resource().latestError?.cause is RequestError.Cause.UnparsableImage) == true
@@ -311,7 +310,7 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                     let resource = service.resource(contentType)
                     _ = stubRequest(resource, "GET").andReturn(200)
                         .withHeader("Content-Type", contentType)
-                        .withBody(Data([0xD8]) as NSData)
+                        .withBody(Data([0xD8]))
                     let awaitRequest = expectSuccess ? awaitNewData : awaitFailure
                     awaitRequest(resource.load(), .inProgress)
                     expect(resource.latestData?.content is Data) == expectSuccess
@@ -424,7 +423,7 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                     configureModelTransformer()
                     _ = stubRequest(resource, "GET").andReturn(500)
                         .withHeader("Content-Type", "text/plain")
-                        .withBody("I am not a model" as NSString)
+                        .withBody("I am not a model")
                     awaitFailure(resource().load())
                     expect(resource().latestData).to(beNil())
                     expect(resource().latestError?.text) == "I am not a model"
@@ -436,7 +435,7 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                         { TestModel(name: $0.content) }
                     _ = stubRequest(resource, "GET").andReturn(500)
                         .withHeader("Content-Type", "text/plain")
-                        .withBody("Fred T. Error" as NSString)
+                        .withBody("Fred T. Error")
                     awaitFailure(resource().load())
                     let model: TestModel? = resource().latestError?.typedContent()
                     expect(model?.name) == "Fred T. Error"
@@ -542,7 +541,7 @@ class ResponseDataHandlingSpec: ResourceSpecBase
                     {
                     _ = stubRequest(resource, method.rawValue.uppercased()).andReturn(200)
                         .withHeader("Content-Type", "text/plain")
-                        .withBody(string as NSString)
+                        .withBody(string)
 
                     var result: Entity<Any>?
                     let req = resource().request(method)

--- a/Tests/Functional/ResponseDataHandlingSpec.swift
+++ b/Tests/Functional/ResponseDataHandlingSpec.swift
@@ -16,14 +16,18 @@ class ResponseDataHandlingSpec: ResourceSpecBase
         {
         func stubText(
                 _ string: String? = "zwobble",
-                method: String = "GET",
                 contentType: String = "text/plain",
                 expectSuccess: Bool = true)
             {
-            _ = stubRequest(resource, method).andReturn(200)
-                .withHeader("Content-Type", contentType)
-                .withHeader("X-Custom-Header", "Sprotzle")
-                .withBody(string)
+            NetworkStub.add(
+                .get, resource,
+                returning: HTTPResponse(
+                    headers:
+                        [
+                        "Content-Type": contentType,
+                        "X-Custom-Header": "Sprotzle"
+                        ],
+                    body: string))
             let awaitRequest = expectSuccess ? awaitNewData : awaitFailure
             awaitRequest(resource().load(), .inProgress)
             }

--- a/Tests/Functional/ServiceSpec.swift
+++ b/Tests/Functional/ServiceSpec.swift
@@ -69,7 +69,7 @@ class ServiceSpec: SiestaSpec
                     it("allows requests for absolute URLs")
                         {
                         let resource = bareService().resource(absoluteURL: "http://foo.bar")
-                        _ = stubRequest({ resource }, "GET").andReturn(200)
+                        NetworkStub.add(.get, { resource })
                         awaitNewData(resource.load())
                         }
                     }

--- a/Tests/Functional/ServiceSpec.swift
+++ b/Tests/Functional/ServiceSpec.swift
@@ -76,10 +76,10 @@ class ServiceSpec: SiestaSpec
                 }
 
             addSpecsForBareServce("with no baseURL")
-                { Service() }
+                { Service(networking: NetworkStub.defaultConfiguration) }
 
             addSpecsForBareServce("with an invalid baseURL")
-                { Service(baseURL: "\0") }
+                { Service(baseURL: "\0", networking: NetworkStub.defaultConfiguration) }
             }
 
         describe("resource(_:)")

--- a/Tests/Functional/SiestaSpec.swift
+++ b/Tests/Functional/SiestaSpec.swift
@@ -15,6 +15,12 @@ private var activeSuites = 0
 
 class SiestaSpec: QuickSpec
     {
+    static func envFlag(_ key: String) -> Bool
+        {
+        let value = ProcessInfo.processInfo.environment["Siesta_\(key)"] ?? ""
+        return value == "1" || value == "true"
+        }
+
     override func spec()
         {
         beforeSuite

--- a/Tests/Functional/SpecHelpers.swift
+++ b/Tests/Functional/SpecHelpers.swift
@@ -8,7 +8,6 @@
 
 import Quick
 import Nimble
-import Nocilla
 @testable import Siesta
 
 func specVar<T>(_ builder: @escaping () -> T) -> () -> T

--- a/Tests/Functional/TestService.swift
+++ b/Tests/Functional/TestService.swift
@@ -7,11 +7,39 @@
 //
 
 import Siesta
+import Quick
 
 @objc
-public class TestService: Service
+public class TestService: Service  // for Obj-C tests only
     {
+    private var allRequests = [Request]()
+
     @objc
     public init()
-        { super.init(baseURL: "http://example.api") }
+        {
+        super.init(
+            baseURL: "http://example.api",
+            networking: NetworkStub.wrap(URLSessionConfiguration.ephemeral))
+
+        configure
+            {
+            $0.decorateRequests
+                {
+                _, request in
+                self.allRequests.append(request)
+                return request
+                }
+            }
+        }
+
+    @objc
+    public func awaitAllRequests()
+        {
+        for req in allRequests
+            {
+            let responseExpectation = QuickSpec.current.expectation(description: "awaiting response callback: \(req)")
+            req.onCompletion { _ in responseExpectation.fulfill() }
+            QuickSpec.current.waitForExpectations(timeout: 1)
+            }
+        }
     }


### PR DESCRIPTION
Went with a small custom network stub to suit Siesta’s somewhat peculiar needs.

Removing Nocilla eliminates some kludgy race condition workarounds, and paves the way for full SwiftPM support.

Fixes #60.