### PR TITLE
Full SwiftPM support

### DIFF
--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -1,0 +1,19 @@
+name: Swift
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: swift build -v
+    - name: Run tests
+      run: Siesta_TestMultipleNetworkProviders=1 swift test -v

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,43 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "CwlCatchException",
+        "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
+        "state": {
+          "branch": null,
+          "revision": "7cd2f8cacc4d22f21bc0b2309c3b18acf7957b66",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "package": "CwlPreconditionTesting",
+        "repositoryURL": "https://github.com/mattgallagher/CwlPreconditionTesting.git",
+        "state": {
+          "branch": null,
+          "revision": "c228db5d2ad1b01ebc84435e823e6cca4e3db98b",
+          "version": "1.2.0"
+        }
+      },
+      {
+        "package": "Nimble",
+        "repositoryURL": "https://github.com/Quick/Nimble",
+        "state": {
+          "branch": null,
+          "revision": "b02b00b30b6353632aa4a5fb6124f8147f7140c0",
+          "version": "8.0.5"
+        }
+      },
+      {
+        "package": "Quick",
+        "repositoryURL": "https://github.com/pcantrell/Quick",
+        "state": {
+          "branch": "around-each",
+          "revision": "d91676d00600c42f9b55349765b1f1099141bfba",
+          "version": null
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "Alamofire",
+        "repositoryURL": "https://github.com/Alamofire/Alamofire",
+        "state": {
+          "branch": null,
+          "revision": "59037bfd28aa963a7916f1eb22a74107a3522f16",
+          "version": "5.0.5"
+        }
+      },
+      {
         "package": "CwlCatchException",
         "repositoryURL": "https://github.com/mattgallagher/CwlCatchException.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -3,15 +3,34 @@ import PackageDescription
 
 let package = Package(
     name: "Siesta",
+    platforms: [
+        .iOS(.v8),
+        .macOS(.v10_11),
+        .tvOS(.v9),
+    ],
     products: [
         .library(name: "Siesta", targets: ["Siesta"]),
-        .library(name: "SiestaUI", targets: ["SiestaUI"])
+        .library(name: "SiestaUI", targets: ["SiestaUI"]),
+    ],
+    dependencies: [
+        // .package(url: "https://github.com/Alamofire/Alamofire", .upToNextMajor(from: "5.0.5")),
+        .package(url: "https://github.com/pcantrell/Quick", .branch("around-each")), 
+        .package(url: "https://github.com/Quick/Nimble", from: "8.0.1"),
     ],
     targets: [
-        .target(name: "Siesta"),
+        .target(
+            name: "Siesta"
+        ),
         .target(
             name: "SiestaUI",
             dependencies: ["Siesta"]
-        )
-    ]
+        ),
+        .testTarget(
+            name: "SiestaTests",
+            dependencies: ["SiestaUI", "Quick", "Nimble"],
+            path: "Tests/Functional",
+            exclude: ["ObjcCompatibilitySpec.m"]  // SwiftPM currently only supports Swift
+        ),
+    ],
+    swiftLanguageVersions: [.v5]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ let package = Package(
     name: "Siesta",
     platforms: [
         .iOS(.v8),
-        .macOS(.v10_11),
+        .macOS(.v10_12),
         .tvOS(.v9),
     ],
     products: [
@@ -13,7 +13,12 @@ let package = Package(
         .library(name: "SiestaUI", targets: ["SiestaUI"]),
     ],
     dependencies: [
-        // .package(url: "https://github.com/Alamofire/Alamofire", .upToNextMajor(from: "5.0.5")),
+        // Siesta has no required third-party dependencies for use in downstream projects.
+
+        // For optional Siesta-Alamofire module:
+        .package(url: "https://github.com/Alamofire/Alamofire", .upToNextMajor(from: "5.0.5")),
+
+        // For tests:
         .package(url: "https://github.com/pcantrell/Quick", .branch("around-each")), 
         .package(url: "https://github.com/Quick/Nimble", from: "8.0.1"),
     ],
@@ -25,9 +30,14 @@ let package = Package(
             name: "SiestaUI",
             dependencies: ["Siesta"]
         ),
+        .target(
+            name: "Siesta_Alamofire",
+            dependencies: ["Siesta", "Alamofire"],
+            path: "Extensions/Alamofire"
+        ),
         .testTarget(
             name: "SiestaTests",
-            dependencies: ["SiestaUI", "Quick", "Nimble"],
+            dependencies: ["SiestaUI", "Siesta_Alamofire", "Quick", "Nimble"],
             path: "Tests/Functional",
             exclude: ["ObjcCompatibilitySpec.m"]  // SwiftPM currently only supports Swift
         ),

--- a/Source/SiestaUI/NetworkActivityIndicator.swift
+++ b/Source/SiestaUI/NetworkActivityIndicator.swift
@@ -64,4 +64,4 @@ extension Configuration
         }
     }
 
-#endif
+#endif // OS(iOS)

--- a/Source/SiestaUI/RemoteImageView.swift
+++ b/Source/SiestaUI/RemoteImageView.swift
@@ -6,11 +6,13 @@
 //  Copyright © 2016 Bust Out Solutions. All rights reserved.
 //
 
+#if os(iOS)
+
 #if !COCOAPODS
     import Siesta
 #endif
-import Foundation
 import UIKit
+import Foundation
 
 /**
   A `UIImageView` that asynchronously loads and displays remote images.
@@ -85,3 +87,5 @@ open class RemoteImageView: UIImageView
         alternateView?.isHidden = (image != nil) || isLoading
         }
     }
+
+#endif // OS(iOS)

--- a/Source/SiestaUI/ResourceStatusOverlay.swift
+++ b/Source/SiestaUI/ResourceStatusOverlay.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2016 Bust Out Solutions. All rights reserved.
 //
 
+#if os(iOS)
+
 #if !COCOAPODS
     import Siesta
 #endif
@@ -322,3 +324,5 @@ open class ResourceStatusOverlay: UIView, ResourceObserver
             }
         }
     }
+
+#endif // OS(iOS)

--- a/Source/SiestaUI/Ω_UI_Deprecations.swift
+++ b/Source/SiestaUI/Ω_UI_Deprecations.swift
@@ -9,5 +9,7 @@
 #if !COCOAPODS
     import Siesta
 #endif
-import UIKit
+#if os(iOS)
+    import UIKit
+#endif
 import Foundation

--- a/Tests/Functional/EntityCacheSpec.swift
+++ b/Tests/Functional/EntityCacheSpec.swift
@@ -7,6 +7,8 @@
 //
 
 import Siesta
+
+import Foundation
 import Quick
 import Nimble
 

--- a/Tests/Functional/NetworkStub-ObjC.swift
+++ b/Tests/Functional/NetworkStub-ObjC.swift
@@ -8,8 +8,9 @@
 
 // swiftlint:disable function_parameter_count missing_docs
 
-import Foundation
 import Siesta
+
+import Foundation
 
 extension NetworkStub
     {

--- a/Tests/Functional/NetworkStub.swift
+++ b/Tests/Functional/NetworkStub.swift
@@ -6,8 +6,9 @@
 //  Copyright © 2020 Bust Out Solutions. All rights reserved.
 //
 
-import Foundation
 import Siesta
+
+import Foundation
 
 public final class NetworkStub: NSObject  // Could be enum but for Obj-C compatibility
     {

--- a/Tests/Functional/PipelineSpec.swift
+++ b/Tests/Functional/PipelineSpec.swift
@@ -7,6 +7,8 @@
 //
 
 import Siesta
+
+import Foundation
 import Quick
 import Nimble
 

--- a/Tests/Functional/ProgressSpec.swift
+++ b/Tests/Functional/ProgressSpec.swift
@@ -7,6 +7,8 @@
 //
 
 @testable import Siesta
+
+import Foundation
 import Quick
 import Nimble
 

--- a/Tests/Functional/RemoteImageViewSpec.swift
+++ b/Tests/Functional/RemoteImageViewSpec.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2018 Bust Out Solutions. All rights reserved.
 //
 
+#if os(iOS)
+
 import Foundation
 
 import SiestaUI
@@ -35,3 +37,5 @@ class RemoteImageViewSpec: SiestaSpec
         // TODO: build out SiestaUI tests
         }
     }
+
+#endif

--- a/Tests/Functional/RequestSpec.swift
+++ b/Tests/Functional/RequestSpec.swift
@@ -7,6 +7,8 @@
 //
 
 import Siesta
+
+import Foundation
 import Quick
 import Nimble
 

--- a/Tests/Functional/ResourceObserversSpec.swift
+++ b/Tests/Functional/ResourceObserversSpec.swift
@@ -7,6 +7,9 @@
 //
 
 import Siesta
+
+import Foundation
+import XCTest
 import Quick
 import Nimble
 

--- a/Tests/Functional/ResourcePathsSpec.swift
+++ b/Tests/Functional/ResourcePathsSpec.swift
@@ -7,6 +7,8 @@
 //
 
 import Siesta
+
+import Foundation
 import Quick
 import Nimble
 

--- a/Tests/Functional/ResourceSpecBase.swift
+++ b/Tests/Functional/ResourceSpecBase.swift
@@ -7,9 +7,13 @@
 //
 
 @testable import Siesta
+
+import Foundation
 import Quick
 import Nimble
-import Alamofire
+#if canImport(Alamofire)
+    import Alamofire
+#endif
 
 private let _fakeNowLock = NSObject()
 private var _fakeNow: Double?
@@ -58,11 +62,13 @@ class ResourceSpecBase: SiestaSpec
                     delegate: nil,
                     delegateQueue: backgroundQueue)
                 }())
+            #if canImport(Alamofire)
             let afSession = Alamofire.Session(
                 configuration: NetworkStub.wrap(
                     Alamofire.Session.default.session.configuration),
                 startRequestsImmediately: false)
             runSpecsWithNetworkingProvider("Alamofire networking", networking: afSession)
+            #endif
             }
         else
             { runSpecsWithDefaultProvider() }

--- a/Tests/Functional/ResourceSpecBase.swift
+++ b/Tests/Functional/ResourceSpecBase.swift
@@ -11,8 +11,9 @@
 import Foundation
 import Quick
 import Nimble
-#if canImport(Alamofire)
-    import Alamofire
+import Alamofire
+#if canImport(Siesta_Alamofire)  // SwiftPM builds it as a separate module
+    import Siesta_Alamofire
 #endif
 
 private let _fakeNowLock = NSObject()

--- a/Tests/Functional/ResourceStateSpec.swift
+++ b/Tests/Functional/ResourceStateSpec.swift
@@ -557,9 +557,9 @@ class ResourceStateSpec: ResourceSpecBase
                     {
                     let expectation = QuickSpec.current.expectation(description: "cancelLoadIfUnobserved(afterDelay:")
                     expectation.isInverted = true
-                    resource().cancelLoadIfUnobserved(afterDelay: 0.2)
+                    resource().cancelLoadIfUnobserved(afterDelay: 0.3)
                         { expectation.fulfill() }
-                    QuickSpec.current.waitForExpectations(timeout: 0.1)
+                    QuickSpec.current.waitForExpectations(timeout: 0.05)
 
                     _ = reqStub().go()
                     awaitNewData(req())

--- a/Tests/Functional/ResourceStateSpec.swift
+++ b/Tests/Functional/ResourceStateSpec.swift
@@ -7,6 +7,8 @@
 //
 
 import Siesta
+
+import Foundation
 import Quick
 import Nimble
 

--- a/Tests/Functional/ResponseDataHandlingSpec.swift
+++ b/Tests/Functional/ResponseDataHandlingSpec.swift
@@ -7,6 +7,8 @@
 //
 
 import Siesta
+
+import Foundation
 import Quick
 import Nimble
 

--- a/Tests/Functional/ServiceSpec.swift
+++ b/Tests/Functional/ServiceSpec.swift
@@ -7,6 +7,9 @@
 //
 
 import Siesta
+
+import Foundation
+import XCTest
 import Quick
 import Nimble
 

--- a/Tests/Functional/SiestaSpec.swift
+++ b/Tests/Functional/SiestaSpec.swift
@@ -6,8 +6,10 @@
 //  Copyright © 2016 Bust Out Solutions. All rights reserved.
 //
 
-import Quick
 @testable import Siesta
+
+import Foundation
+import Quick
 
 private var currentLogMessages: [String] = []
 private var currentTestFailed: Bool = false
@@ -125,7 +127,7 @@ private class ResultsAggregator
             }
         else
             {
-            subtree.file = callsite.file
+            subtree.file = callsite.file.description
             subtree.line = callsite.line
             subtree.passed = passed
             }

--- a/Tests/Functional/SpecHelpers.swift
+++ b/Tests/Functional/SpecHelpers.swift
@@ -6,9 +6,11 @@
 //  Copyright © 2016 Bust Out Solutions. All rights reserved.
 //
 
+@testable import Siesta
+
+import Foundation
 import Quick
 import Nimble
-@testable import Siesta
 
 func specVar<T>(_ builder: @escaping () -> T) -> () -> T
     {

--- a/Tests/Functional/TestService.swift
+++ b/Tests/Functional/TestService.swift
@@ -7,6 +7,8 @@
 //
 
 import Siesta
+
+import Foundation
 import Quick
 
 @objc

--- a/Tests/Functional/WeakCacheSpec.swift
+++ b/Tests/Functional/WeakCacheSpec.swift
@@ -7,6 +7,9 @@
 //
 
 @testable import Siesta
+
+import Foundation
+import XCTest
 import Quick
 import Nimble
 


### PR DESCRIPTION
- `swift test` now works (yay!)
- imports fixed for compilation outside of Xcode
- package manifest now properly declares language & platform versions
- package now exposes Alamofire extension as a module