### PR TITLE
File cache

### DIFF
--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -2,9 +2,9 @@ name: SwiftPM regression tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main, ci-experiments ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   test:

--- a/.github/workflows/xcode.yml
+++ b/.github/workflows/xcode.yml
@@ -2,9 +2,9 @@ name: Xcode regression tests
 
 on:
   push:
-    branches: [ $default-branch, main, master, ci-experiments ]
+    branches: [ main, ci-experiments ]
   pull_request:
-    branches: [ $default-branch, main, master ]
+    branches: [ main ]
 
 jobs:
   test:

--- a/Examples/GithubBrowser/GithubBrowser.xcodeproj/xcshareddata/xcschemes/GithubBrowser.xcscheme
+++ b/Examples/GithubBrowser/GithubBrowser.xcodeproj/xcshareddata/xcschemes/GithubBrowser.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1140"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DA7462381B4C768B00406D67"
+               BuildableName = "GithubBrowser.app"
+               BlueprintName = "GithubBrowser"
+               ReferencedContainer = "container:GithubBrowser.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DA7462381B4C768B00406D67"
+            BuildableName = "GithubBrowser.app"
+            BlueprintName = "GithubBrowser"
+            ReferencedContainer = "container:GithubBrowser.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DA7462381B4C768B00406D67"
+            BuildableName = "GithubBrowser.app"
+            BlueprintName = "GithubBrowser"
+            ReferencedContainer = "container:GithubBrowser.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Examples/GithubBrowser/Source/API/GithubAPI.swift
+++ b/Examples/GithubBrowser/Source/API/GithubAPI.swift
@@ -17,7 +17,7 @@ class _GitHubAPI {
     fileprivate init() {
         #if DEBUG
             // Bare-bones logging of which network calls Siesta makes:
-            SiestaLog.Category.enabled = [.network]
+            SiestaLog.Category.enabled = [.network, .cache]
 
             // For more info about how Siesta decides whether to make a network call,
             // and which state updates it broadcasts to the app:
@@ -44,7 +44,39 @@ class _GitHubAPI {
 
             $0.pipeline[.cleanup].add(
               GitHubErrorMessageExtractor(jsonDecoder: jsonDecoder))
+
+            // Cache API results for fast launch & offline access:
+
+            $0.pipeline[.rawData].cacheUsing {
+                try FileCache<Data>(
+                    poolName: "api.github.com",
+                    dataIsolation: .perUser(identifiedBy: self.username))  // Show each user their own data
+            }
+
+            // Using the closure form of cacheUsing above signals that if we encounter an error trying create a cache
+            // directory or generate a cache isolation key from the username, we should simply proceed silently without
+            // having a persistent cache.
+
+            // Note that the dataIsolation uses only username. This means that users will not _see_ other users’ data;
+            // however, it does not _secure_ one user’s data from another. A user with permission to see the cache
+            // directory could in principle see all the cached data.
+            //
+            // To fully secure one user’s data from another, the application would need to generate some long-lived
+            // secret that is unique to each user. A password can work, though it will essentially empty the user’s
+            // cache if the password changes. The server could also send some kind of high-entropy per-user token in
+            // the authentication response.
         }
+
+        RemoteImageView.defaultImageService.configure {
+            // We can cache images offline too:
+
+            $0.pipeline[.rawData].cacheUsing {
+                try FileCache<Data>(
+                    poolName: "images",
+                    dataIsolation: .sharedByAllUsers)  // images aren't secret, so no need to isolate them
+            }
+        }
+
 
         // –––––– Resource-specific configuration ––––––
 
@@ -116,18 +148,22 @@ class _GitHubAPI {
     // MARK: - Authentication
 
     func logIn(username: String, password: String) {
-        if let auth = "\(username):\(password)".data(using: String.Encoding.utf8) {
+        self.username = username
+        if let auth = "\(username):\(password)".data(using: .utf8) {
             basicAuthHeader = "Basic \(auth.base64EncodedString())"
         }
     }
 
     func logOut() {
+        username = nil
         basicAuthHeader = nil
     }
 
     var isAuthenticated: Bool {
         return basicAuthHeader != nil
     }
+
+    private var username: String?
 
     private var basicAuthHeader: String? {
         didSet {

--- a/Examples/GithubBrowser/Source/API/GithubAPI.swift
+++ b/Examples/GithubBrowser/Source/API/GithubAPI.swift
@@ -83,6 +83,9 @@ class _GitHubAPI {
         service.configure("/search/**") {
             // Refresh search results after 10 seconds (Siesta default is 30)
             $0.expirationTime = 10
+
+            // Don't cache search results between runs, so we don't see stale results on launch
+            $0.pipeline.removeAllCaches()
         }
 
         // –––––– Auth configuration ––––––

--- a/Examples/GithubBrowser/Source/UI/RepositoryListViewController.swift
+++ b/Examples/GithubBrowser/Source/UI/RepositoryListViewController.swift
@@ -38,7 +38,9 @@ class RepositoryListViewController: UITableViewController, ResourceObserver {
         super.viewDidLoad()
 
         view.backgroundColor = SiestaTheme.darkColor
+
         statusOverlay.embed(in: self)
+        statusOverlay.displayPriority = [.anyData, .loading, .error]
     }
 
     override func viewDidLayoutSubviews() {

--- a/Examples/GithubBrowser/Source/UI/RepositoryViewController.swift
+++ b/Examples/GithubBrowser/Source/UI/RepositoryViewController.swift
@@ -76,6 +76,7 @@ class RepositoryViewController: UIViewController, ResourceObserver {
         super.viewDidLoad()
 
         view.backgroundColor = SiestaTheme.darkColor
+
         statusOverlay.embed(in: self)
         statusOverlay.displayPriority = [.anyData, .loading, .error]  // Prioritize partial data over loading indicator
 

--- a/Examples/GithubBrowser/Source/UI/UserViewController.swift
+++ b/Examples/GithubBrowser/Source/UI/UserViewController.swift
@@ -53,6 +53,8 @@ class UserViewController: UIViewController, UISearchBarDelegate, ResourceObserve
         view.backgroundColor = SiestaTheme.darkColor
 
         statusOverlay.embed(in: self)
+        statusOverlay.displayPriority = [.anyData, .loading, .error]
+
         showUser(nil)
 
         searchBar.becomeFirstResponder()

--- a/Package.swift
+++ b/Package.swift
@@ -28,6 +28,10 @@ let package = Package(
             name: "Siesta"
         ),
         .target(
+            name: "SiestaTools",
+            dependencies: ["Siesta"]
+        ),
+        .target(
             name: "SiestaUI",
             dependencies: ["Siesta"],
             resources: [.process("ResourceStatusOverlay.xib")],
@@ -42,7 +46,7 @@ let package = Package(
         ),
         .testTarget(
             name: "SiestaTests",
-            dependencies: ["SiestaUI", "Siesta_Alamofire", "Quick", "Nimble"],
+            dependencies: ["SiestaUI", "SiestaTools", "Siesta_Alamofire", "Quick", "Nimble"],
             path: "Tests/Functional",
             exclude: ["ObjcCompatibilitySpec.m"]  // SwiftPM currently only supports Swift
         ),

--- a/Siesta.podspec
+++ b/Siesta.podspec
@@ -79,6 +79,12 @@ Pod::Spec.new do |s|
     s.exclude_files = "**/Info*.plist"
   end
 
+  s.subspec "Tools" do |s|
+    s.source_files = "Source/SiestaTools/**/*"
+    s.exclude_files = "**/Info*.plist"
+    s.dependency "Siesta/Core"
+  end
+
   s.subspec "UI" do |s|
     s.ios.source_files = "Source/SiestaUI/**/*.{swift,m,h}"
     s.dependency "Siesta/Core"

--- a/Siesta.xcodeproj/project.pbxproj
+++ b/Siesta.xcodeproj/project.pbxproj
@@ -188,9 +188,12 @@
 		DA788A8F1D6AC1590085C820 /* ObjcCompatibilitySpec.m in Sources */ = {isa = PBXBuildFile; fileRef = DA4D61971B751FEE00F6BB9C /* ObjcCompatibilitySpec.m */; };
 		DA7D05C41D57C2B500431980 /* PipelineProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7D05C31D57C2B500431980 /* PipelineProcessing.swift */; };
 		DA7D05C51D57C30400431980 /* PipelineProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7D05C31D57C2B500431980 /* PipelineProcessing.swift */; };
-		DA8B5B5522DEAC93008E47B0 /* SiestaTools.h in Headers */ = {isa = PBXBuildFile; fileRef = DA8C83571FC6096100C947F9 /* SiestaTools.h */; };
-		DA8B5B6422DEADDB008E47B0 /* SiestaTools.h in Headers */ = {isa = PBXBuildFile; fileRef = DA8C83571FC6096100C947F9 /* SiestaTools.h */; };
-		DA8C83581FC6096100C947F9 /* SiestaTools.h in Headers */ = {isa = PBXBuildFile; fileRef = DA8C83571FC6096100C947F9 /* SiestaTools.h */; };
+		DA8B5B5522DEAC93008E47B0 /* SiestaTools.h in Headers */ = {isa = PBXBuildFile; fileRef = DA8C83571FC6096100C947F9 /* SiestaTools.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DA8B5B6422DEADDB008E47B0 /* SiestaTools.h in Headers */ = {isa = PBXBuildFile; fileRef = DA8C83571FC6096100C947F9 /* SiestaTools.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DA8B5B7122DEB0DF008E47B0 /* FileCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8DEB491FC6763300555D92 /* FileCache.swift */; };
+		DA8B5B7222DEB0DF008E47B0 /* FileCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8DEB491FC6763300555D92 /* FileCache.swift */; };
+		DA8C83581FC6096100C947F9 /* SiestaTools.h in Headers */ = {isa = PBXBuildFile; fileRef = DA8C83571FC6096100C947F9 /* SiestaTools.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DA8DEB4A1FC6763300555D92 /* FileCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8DEB491FC6763300555D92 /* FileCache.swift */; };
 		DA8EF6D11BC20AFE002175EB /* ProgressSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8EF6CF1BC1A917002175EB /* ProgressSpec.swift */; };
 		DA99B5C91B38C8E6009C6937 /* String+Siesta.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA99B5C81B38C8E6009C6937 /* String+Siesta.swift */; };
 		DA9AA8151CCAFDD20016DB18 /* ConfigurationPatternConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9AA8141CCAFDD20016DB18 /* ConfigurationPatternConvertible.swift */; };
@@ -457,6 +460,7 @@
 		DA8B5B6922DEADDB008E47B0 /* SiestaTools.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SiestaTools.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA8C83521FC600A900C947F9 /* SiestaTools.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SiestaTools.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DA8C83571FC6096100C947F9 /* SiestaTools.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SiestaTools.h; sourceTree = "<group>"; };
+		DA8DEB491FC6763300555D92 /* FileCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileCache.swift; sourceTree = "<group>"; };
 		DA8EF6CF1BC1A917002175EB /* ProgressSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgressSpec.swift; sourceTree = "<group>"; };
 		DA99B5C81B38C8E6009C6937 /* String+Siesta.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Siesta.swift"; sourceTree = "<group>"; };
 		DA9AA8141CCAFDD20016DB18 /* ConfigurationPatternConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigurationPatternConvertible.swift; sourceTree = "<group>"; };
@@ -728,6 +732,7 @@
 		DA8C833F1FC5FFDA00C947F9 /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				DA8DEB491FC6763300555D92 /* FileCache.swift */,
 			);
 			name = Tools;
 			path = SiestaTools;
@@ -1272,6 +1277,9 @@
 					DA5E4B3922DCE9670059ED10 = {
 						ProvisioningStyle = Manual;
 					};
+					DA8C83401FC600A900C947F9 = {
+						LastSwiftMigration = 0910;
+					};
 					DAC0B37D1D651CB500D25C44 = {
 						LastSwiftMigration = 1000;
 					};
@@ -1754,6 +1762,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA8B5B7122DEB0DF008E47B0 /* FileCache.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1761,6 +1770,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA8B5B7222DEB0DF008E47B0 /* FileCache.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1768,6 +1778,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				DA8DEB4A1FC6763300555D92 /* FileCache.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1880,6 +1891,7 @@
 		9F0FAFAA1D033FCD00CE1B61 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Tests/Info-macOS.plist";
@@ -1897,6 +1909,7 @@
 		9F0FAFAB1D033FCD00CE1B61 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				COMBINE_HIDPI_IMAGES = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Tests/Info-macOS.plist";
@@ -2310,6 +2323,7 @@
 		DA336E671B2E6DDB006F702A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Tests/Info-iOS.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -2325,6 +2339,7 @@
 		DA336E681B2E6DDB006F702A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CLANG_ENABLE_MODULES = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Tests/Info-iOS.plist";
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/Siesta.xcodeproj/project.pbxproj
+++ b/Siesta.xcodeproj/project.pbxproj
@@ -144,6 +144,12 @@
 		DA34E2C9222BAAE70025A77A /* Optional+Siesta.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA34E2C7222BA8650025A77A /* Optional+Siesta.swift */; };
 		DA34E2CA222BAAEA0025A77A /* Optional+Siesta.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA34E2C7222BA8650025A77A /* Optional+Siesta.swift */; };
 		DA34E2CB222BAAEB0025A77A /* Optional+Siesta.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA34E2C7222BA8650025A77A /* Optional+Siesta.swift */; };
+		DA3E165F243C24A3001F7CCA /* FileCacheSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3E165E243C24A3001F7CCA /* FileCacheSpec.swift */; };
+		DA3E1660243C24A3001F7CCA /* FileCacheSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3E165E243C24A3001F7CCA /* FileCacheSpec.swift */; };
+		DA3E1661243C24A3001F7CCA /* FileCacheSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3E165E243C24A3001F7CCA /* FileCacheSpec.swift */; };
+		DA3E1662243D6D00001F7CCA /* SiestaTools.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA8B5B5A22DEAC93008E47B0 /* SiestaTools.framework */; };
+		DA3E1663243D6D0E001F7CCA /* SiestaTools.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA8C83521FC600A900C947F9 /* SiestaTools.framework */; };
+		DA3E1664243D6D18001F7CCA /* SiestaTools.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DA8B5B6922DEADDB008E47B0 /* SiestaTools.framework */; };
 		DA3FBD9B1B55917600161A25 /* Siesta-ObjC.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3FBD9A1B55917600161A25 /* Siesta-ObjC.swift */; };
 		DA3FBDB11B55BF0E00161A25 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA3FBDB01B55BF0E00161A25 /* Logging.swift */; };
 		DA3FD66C1D0DF5DE00C75742 /* PipelineConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACE0BAD1D0201F800607F3E /* PipelineConfiguration.swift */; };
@@ -439,6 +445,7 @@
 		DA336E601B2E6DDB006F702A /* Info-iOS.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "Info-iOS.plist"; sourceTree = "<group>"; };
 		DA336E701B2F6659006F702A /* Service.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
 		DA34E2C7222BA8650025A77A /* Optional+Siesta.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Optional+Siesta.swift"; sourceTree = "<group>"; };
+		DA3E165E243C24A3001F7CCA /* FileCacheSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCacheSpec.swift; sourceTree = "<group>"; };
 		DA3FBD9A1B55917600161A25 /* Siesta-ObjC.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Siesta-ObjC.swift"; sourceTree = "<group>"; };
 		DA3FBDB01B55BF0E00161A25 /* Logging.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
 		DA4353511B6AD63C00543843 /* Networking.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Networking.swift; sourceTree = "<group>"; };
@@ -509,6 +516,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9F0FAFB01D033FF400CE1B61 /* Siesta.framework in Frameworks */,
+				DA3E1662243D6D00001F7CCA /* SiestaTools.framework in Frameworks */,
 				DAC4CFCE1DAC10FD00EECEDE /* SiestaUI.framework in Frameworks */,
 				DAF2B7A827189B5A00E5B31A /* Quick in Frameworks */,
 				DAF2B7A627189B5A00E5B31A /* Alamofire in Frameworks */,
@@ -542,6 +550,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CDCCAF7B1E6A31DA00860D18 /* Siesta.framework in Frameworks */,
+				DA3E1664243D6D18001F7CCA /* SiestaTools.framework in Frameworks */,
 				DA5E4B5B22DCF0BB0059ED10 /* SiestaUI.framework in Frameworks */,
 				DAA9102427239BDE00B2211D /* Nimble in Frameworks */,
 				DAA9102027239BDE00B2211D /* Alamofire in Frameworks */,
@@ -569,6 +578,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DA336E5A1B2E6DDB006F702A /* Siesta.framework in Frameworks */,
+				DA3E1663243D6D0E001F7CCA /* SiestaTools.framework in Frameworks */,
 				DAC4CFCF1DAC110500EECEDE /* SiestaUI.framework in Frameworks */,
 				DAA9101E27239BD700B2211D /* Nimble in Frameworks */,
 				DAA9101A27239BD700B2211D /* Alamofire in Frameworks */,
@@ -725,6 +735,7 @@
 				DA9F4BDD1B3F8E2E00E8966F /* WeakCacheSpec.swift */,
 				DA4D61971B751FEE00F6BB9C /* ObjcCompatibilitySpec.m */,
 				DA99B5C71B38C36A009C6937 /* Support */,
+				DA3E165E243C24A3001F7CCA /* FileCacheSpec.swift */,
 			);
 			path = Functional;
 			sourceTree = "<group>";
@@ -1501,6 +1512,7 @@
 				DA788A8F1D6AC1590085C820 /* ObjcCompatibilitySpec.m in Sources */,
 				9F0FAF991D033FCD00CE1B61 /* TestService.swift in Sources */,
 				9F0FAF9A1D033FCD00CE1B61 /* SiestaSpec.swift in Sources */,
+				DA3E1660243C24A3001F7CCA /* FileCacheSpec.swift in Sources */,
 				DA5A90312054E0C500309D8B /* EntityCacheSpec.swift in Sources */,
 				9F0FAF9B1D033FCD00CE1B61 /* ResourcePathsSpec.swift in Sources */,
 				DA7285E71D0DF46600132CD9 /* PipelineSpec.swift in Sources */,
@@ -1650,6 +1662,7 @@
 				CD5651F71E6F306B009F224A /* ResponseDataHandlingSpec.swift in Sources */,
 				CD5651F21E6F306B009F224A /* ResourcePathsSpec.swift in Sources */,
 				CD5651F81E6F306B009F224A /* ProgressSpec.swift in Sources */,
+				DA3E1661243C24A3001F7CCA /* FileCacheSpec.swift in Sources */,
 				DA5E4B5C22DCF1260059ED10 /* RemoteImageViewSpec.swift in Sources */,
 				DA62C9862428670500398674 /* NetworkStub.swift in Sources */,
 				CD5651F11E6F306B009F224A /* ResourceSpecBase.swift in Sources */,
@@ -1728,6 +1741,7 @@
 				DA2FF1061C0F97F600C98FF1 /* Networking-Alamofire.swift in Sources */,
 				DA8EF6D11BC20AFE002175EB /* ProgressSpec.swift in Sources */,
 				DAC0CE6D1B4A3ADA004FBB4B /* ResourceObserversSpec.swift in Sources */,
+				DA3E165F243C24A3001F7CCA /* FileCacheSpec.swift in Sources */,
 				DA49EA801B36174700AE1B8F /* SpecHelpers.swift in Sources */,
 				DA62C9842428670400398674 /* NetworkStub.swift in Sources */,
 				DA9F4BDE1B3F8E2E00E8966F /* WeakCacheSpec.swift in Sources */,

--- a/Siesta.xcodeproj/project.pbxproj
+++ b/Siesta.xcodeproj/project.pbxproj
@@ -188,6 +188,9 @@
 		DA788A8F1D6AC1590085C820 /* ObjcCompatibilitySpec.m in Sources */ = {isa = PBXBuildFile; fileRef = DA4D61971B751FEE00F6BB9C /* ObjcCompatibilitySpec.m */; };
 		DA7D05C41D57C2B500431980 /* PipelineProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7D05C31D57C2B500431980 /* PipelineProcessing.swift */; };
 		DA7D05C51D57C30400431980 /* PipelineProcessing.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA7D05C31D57C2B500431980 /* PipelineProcessing.swift */; };
+		DA8B5B5522DEAC93008E47B0 /* SiestaTools.h in Headers */ = {isa = PBXBuildFile; fileRef = DA8C83571FC6096100C947F9 /* SiestaTools.h */; };
+		DA8B5B6422DEADDB008E47B0 /* SiestaTools.h in Headers */ = {isa = PBXBuildFile; fileRef = DA8C83571FC6096100C947F9 /* SiestaTools.h */; };
+		DA8C83581FC6096100C947F9 /* SiestaTools.h in Headers */ = {isa = PBXBuildFile; fileRef = DA8C83571FC6096100C947F9 /* SiestaTools.h */; };
 		DA8EF6D11BC20AFE002175EB /* ProgressSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA8EF6CF1BC1A917002175EB /* ProgressSpec.swift */; };
 		DA99B5C91B38C8E6009C6937 /* String+Siesta.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA99B5C81B38C8E6009C6937 /* String+Siesta.swift */; };
 		DA9AA8151CCAFDD20016DB18 /* ConfigurationPatternConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA9AA8141CCAFDD20016DB18 /* ConfigurationPatternConvertible.swift */; };
@@ -292,6 +295,48 @@
 			proxyType = 1;
 			remoteGlobalIDString = DA5E4B3922DCE9670059ED10;
 			remoteInfo = "SiestaUI tvOS";
+		};
+		DA8B5B5C22DEACA4008E47B0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DA336E461B2E6DDB006F702A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 9F2FB51D1C28645E0068DFFA;
+			remoteInfo = "Siesta macOS";
+		};
+		DA8B5B6B22DEAE72008E47B0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DA336E461B2E6DDB006F702A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = CDCCAF711E6A31D900860D18;
+			remoteInfo = "Siesta tvOS";
+		};
+		DA8B5B6D22DEAE97008E47B0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DA336E461B2E6DDB006F702A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DA8B5B4F22DEAC93008E47B0;
+			remoteInfo = "SiestaTools macOS";
+		};
+		DA8B5B6F22DEAEA2008E47B0 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DA336E461B2E6DDB006F702A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DA8B5B5E22DEADDB008E47B0;
+			remoteInfo = "SiestaTools tvOS";
+		};
+		DA8C83421FC600A900C947F9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DA336E461B2E6DDB006F702A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DA336E4E1B2E6DDB006F702A;
+			remoteInfo = "SiestaTools iOS";
+		};
+		DA8C83591FC60A2900C947F9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = DA336E461B2E6DDB006F702A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = DA8C83401FC600A900C947F9;
+			remoteInfo = "SiestaTools iOS";
 		};
 		DAC4CFCA1DAC10EC00EECEDE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -408,6 +453,10 @@
 		DA60F5FB1B30B2F800D76DC6 /* Resource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Resource.swift; sourceTree = "<group>"; };
 		DA62C97C2428589B00398674 /* NetworkStub.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkStub.swift; sourceTree = "<group>"; };
 		DA7D05C31D57C2B500431980 /* PipelineProcessing.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PipelineProcessing.swift; sourceTree = "<group>"; };
+		DA8B5B5A22DEAC93008E47B0 /* SiestaTools.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SiestaTools.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA8B5B6922DEADDB008E47B0 /* SiestaTools.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SiestaTools.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA8C83521FC600A900C947F9 /* SiestaTools.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SiestaTools.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DA8C83571FC6096100C947F9 /* SiestaTools.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SiestaTools.h; sourceTree = "<group>"; };
 		DA8EF6CF1BC1A917002175EB /* ProgressSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgressSpec.swift; sourceTree = "<group>"; };
 		DA99B5C81B38C8E6009C6937 /* String+Siesta.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Siesta.swift"; sourceTree = "<group>"; };
 		DA9AA8141CCAFDD20016DB18 /* ConfigurationPatternConvertible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConfigurationPatternConvertible.swift; sourceTree = "<group>"; };
@@ -530,6 +579,27 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DA8B5B5322DEAC93008E47B0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA8B5B6222DEADDB008E47B0 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA8C834A1FC600A900C947F9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DAC0B3A21D651CB500D25C44 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -617,6 +687,9 @@
 				CDCCAF721E6A31D900860D18 /* Siesta.framework */,
 				CDCCAF7A1E6A31DA00860D18 /* SiestaTests.xctest */,
 				DA5E4B4B22DCE9670059ED10 /* SiestaUI.framework */,
+				DA8C83521FC600A900C947F9 /* SiestaTools.framework */,
+				DA8B5B5A22DEAC93008E47B0 /* SiestaTools.framework */,
+				DA8B5B6922DEADDB008E47B0 /* SiestaTools.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -625,6 +698,7 @@
 			isa = PBXGroup;
 			children = (
 				DAC0B37B1D651A4600D25C44 /* Core */,
+				DA8C833F1FC5FFDA00C947F9 /* Tools */,
 				DAE490981B4E51AA004D97D6 /* UI (iOS) */,
 			);
 			path = Source;
@@ -651,6 +725,14 @@
 			path = Functional;
 			sourceTree = "<group>";
 		};
+		DA8C833F1FC5FFDA00C947F9 /* Tools */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Tools;
+			path = SiestaTools;
+			sourceTree = "<group>";
+		};
 		DA99B5C61B38C356009C6937 /* Support */ = {
 			isa = PBXGroup;
 			children = (
@@ -659,6 +741,7 @@
 				CDCCAF681E6A313800860D18 /* Info-watchOS.plist */,
 				CDCCAF751E6A31D900860D18 /* Info-tvOS.plist */,
 				DA336E521B2E6DDB006F702A /* Siesta.h */,
+				DA8C83571FC6096100C947F9 /* SiestaTools.h */,
 				DA6022801D65590800FB5673 /* SiestaUI.h */,
 				DA3FBD9A1B55917600161A25 /* Siesta-ObjC.swift */,
 				DA9F4BDB1B3DFE3700E8966F /* WeakCache.swift */,
@@ -811,6 +894,30 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DA8B5B5422DEAC93008E47B0 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA8B5B5522DEAC93008E47B0 /* SiestaTools.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA8B5B6322DEADDB008E47B0 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA8B5B6422DEADDB008E47B0 /* SiestaTools.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA8C834B1FC600A900C947F9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DA8C83581FC6096100C947F9 /* SiestaTools.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DAC0B3A31D651CB500D25C44 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -844,6 +951,7 @@
 			);
 			dependencies = (
 				9F0FAFAF1D033FE800CE1B61 /* PBXTargetDependency */,
+				DA8B5B6E22DEAE97008E47B0 /* PBXTargetDependency */,
 				DAC4CFCD1DAC10F500EECEDE /* PBXTargetDependency */,
 			);
 			name = "SiestaTests macOS";
@@ -926,6 +1034,7 @@
 			);
 			dependencies = (
 				CDCCAF7D1E6A31DA00860D18 /* PBXTargetDependency */,
+				DA8B5B7022DEAEA2008E47B0 /* PBXTargetDependency */,
 				DA5E4B5122DCEFCA0059ED10 /* PBXTargetDependency */,
 			);
 			name = "SiestaTests tvOS";
@@ -991,6 +1100,7 @@
 			);
 			dependencies = (
 				DA336E5C1B2E6DDB006F702A /* PBXTargetDependency */,
+				DA8C835A1FC60A2900C947F9 /* PBXTargetDependency */,
 				DAC4CFCB1DAC10EC00EECEDE /* PBXTargetDependency */,
 			);
 			name = "SiestaTests iOS";
@@ -1020,6 +1130,63 @@
 			name = "SiestaUI tvOS";
 			productName = Siesta;
 			productReference = DA5E4B4B22DCE9670059ED10 /* SiestaUI.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		DA8B5B4F22DEAC93008E47B0 /* SiestaTools macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DA8B5B5722DEAC93008E47B0 /* Build configuration list for PBXNativeTarget "SiestaTools macOS" */;
+			buildPhases = (
+				DA8B5B5222DEAC93008E47B0 /* Sources */,
+				DA8B5B5322DEAC93008E47B0 /* Frameworks */,
+				DA8B5B5422DEAC93008E47B0 /* Headers */,
+				DA8B5B5622DEAC93008E47B0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DA8B5B5D22DEACA4008E47B0 /* PBXTargetDependency */,
+			);
+			name = "SiestaTools macOS";
+			productName = Siesta;
+			productReference = DA8B5B5A22DEAC93008E47B0 /* SiestaTools.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		DA8B5B5E22DEADDB008E47B0 /* SiestaTools tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DA8B5B6622DEADDB008E47B0 /* Build configuration list for PBXNativeTarget "SiestaTools tvOS" */;
+			buildPhases = (
+				DA8B5B6122DEADDB008E47B0 /* Sources */,
+				DA8B5B6222DEADDB008E47B0 /* Frameworks */,
+				DA8B5B6322DEADDB008E47B0 /* Headers */,
+				DA8B5B6522DEADDB008E47B0 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DA8B5B6C22DEAE72008E47B0 /* PBXTargetDependency */,
+			);
+			name = "SiestaTools tvOS";
+			productName = Siesta;
+			productReference = DA8B5B6922DEADDB008E47B0 /* SiestaTools.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		DA8C83401FC600A900C947F9 /* SiestaTools iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = DA8C834F1FC600A900C947F9 /* Build configuration list for PBXNativeTarget "SiestaTools iOS" */;
+			buildPhases = (
+				DA8C83431FC600A900C947F9 /* Sources */,
+				DA8C834A1FC600A900C947F9 /* Frameworks */,
+				DA8C834B1FC600A900C947F9 /* Headers */,
+				DA8C834D1FC600A900C947F9 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				DA8C83411FC600A900C947F9 /* PBXTargetDependency */,
+			);
+			name = "SiestaTools iOS";
+			productName = Siesta;
+			productReference = DA8C83521FC600A900C947F9 /* SiestaTools.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		DAC0B37D1D651CB500D25C44 /* SiestaUI iOS */ = {
@@ -1135,6 +1302,9 @@
 				9F2FB51D1C28645E0068DFFA /* Siesta macOS */,
 				CDCCAF641E6A313800860D18 /* Siesta watchOS */,
 				CDCCAF711E6A31D900860D18 /* Siesta tvOS */,
+				DA8C83401FC600A900C947F9 /* SiestaTools iOS */,
+				DA8B5B4F22DEAC93008E47B0 /* SiestaTools macOS */,
+				DA8B5B5E22DEADDB008E47B0 /* SiestaTools tvOS */,
 				DAC0B37D1D651CB500D25C44 /* SiestaUI iOS */,
 				DAC0B3AC1D651CC700D25C44 /* SiestaUI macOS */,
 				DA5E4B3922DCE9670059ED10 /* SiestaUI tvOS */,
@@ -1204,6 +1374,27 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		DA5E4B4622DCE9670059ED10 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA8B5B5622DEAC93008E47B0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA8B5B6522DEADDB008E47B0 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA8C834D1FC600A900C947F9 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1559,6 +1750,27 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		DA8B5B5222DEAC93008E47B0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA8B5B6122DEADDB008E47B0 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		DA8C83431FC600A900C947F9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DAC0B37E1D651CB500D25C44 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1611,6 +1823,36 @@
 			isa = PBXTargetDependency;
 			target = DA5E4B3922DCE9670059ED10 /* SiestaUI tvOS */;
 			targetProxy = DA5E4B5022DCEFCA0059ED10 /* PBXContainerItemProxy */;
+		};
+		DA8B5B5D22DEACA4008E47B0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 9F2FB51D1C28645E0068DFFA /* Siesta macOS */;
+			targetProxy = DA8B5B5C22DEACA4008E47B0 /* PBXContainerItemProxy */;
+		};
+		DA8B5B6C22DEAE72008E47B0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = CDCCAF711E6A31D900860D18 /* Siesta tvOS */;
+			targetProxy = DA8B5B6B22DEAE72008E47B0 /* PBXContainerItemProxy */;
+		};
+		DA8B5B6E22DEAE97008E47B0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DA8B5B4F22DEAC93008E47B0 /* SiestaTools macOS */;
+			targetProxy = DA8B5B6D22DEAE97008E47B0 /* PBXContainerItemProxy */;
+		};
+		DA8B5B7022DEAEA2008E47B0 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DA8B5B5E22DEADDB008E47B0 /* SiestaTools tvOS */;
+			targetProxy = DA8B5B6F22DEAEA2008E47B0 /* PBXContainerItemProxy */;
+		};
+		DA8C83411FC600A900C947F9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DA336E4E1B2E6DDB006F702A /* Siesta iOS */;
+			targetProxy = DA8C83421FC600A900C947F9 /* PBXContainerItemProxy */;
+		};
+		DA8C835A1FC60A2900C947F9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = DA8C83401FC600A900C947F9 /* SiestaTools iOS */;
+			targetProxy = DA8C83591FC60A2900C947F9 /* PBXContainerItemProxy */;
 		};
 		DAC4CFCB1DAC10EC00EECEDE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2144,6 +2386,127 @@
 			};
 			name = Release;
 		};
+		DA8B5B5822DEAC93008E47B0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/Source/Info-macOS.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bustoutsolutions.SiestaTools;
+				PRODUCT_NAME = SiestaTools;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		DA8B5B5922DEAC93008E47B0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/Source/Info-macOS.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bustoutsolutions.SiestaTools;
+				PRODUCT_NAME = SiestaTools;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		DA8B5B6722DEADDB008E47B0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/Source/Info-tvOS.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bustoutsolutions.SiestaTools;
+				PRODUCT_NAME = SiestaTools;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		DA8B5B6822DEADDB008E47B0 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/Source/Info-tvOS.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bustoutsolutions.SiestaTools;
+				PRODUCT_NAME = SiestaTools;
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		DA8C83501FC600A900C947F9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/Source/Info-iOS.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bustoutsolutions.SiestaTools;
+				PRODUCT_NAME = SiestaTools;
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		DA8C83511FC600A900C947F9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = "$(SRCROOT)/Source/Info-iOS.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.bustoutsolutions.SiestaTools;
+				PRODUCT_NAME = SiestaTools;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
 		DAC0B3A81D651CB500D25C44 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2314,6 +2677,33 @@
 			buildConfigurations = (
 				DA5E4B4922DCE9670059ED10 /* Debug */,
 				DA5E4B4A22DCE9670059ED10 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DA8B5B5722DEAC93008E47B0 /* Build configuration list for PBXNativeTarget "SiestaTools macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DA8B5B5822DEAC93008E47B0 /* Debug */,
+				DA8B5B5922DEAC93008E47B0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DA8B5B6622DEADDB008E47B0 /* Build configuration list for PBXNativeTarget "SiestaTools tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DA8B5B6722DEADDB008E47B0 /* Debug */,
+				DA8B5B6822DEADDB008E47B0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		DA8C834F1FC600A900C947F9 /* Build configuration list for PBXNativeTarget "SiestaTools iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				DA8C83501FC600A900C947F9 /* Debug */,
+				DA8C83511FC600A900C947F9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Siesta.xcodeproj/xcshareddata/xcschemes/SiestaTools iOS.xcscheme
+++ b/Siesta.xcodeproj/xcshareddata/xcschemes/SiestaTools iOS.xcscheme
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0910"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DA8C83401FC600A900C947F9"
+               BuildableName = "SiestaTools.framework"
+               BlueprintName = "SiestaTools iOS"
+               ReferencedContainer = "container:Siesta.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DA8C83401FC600A900C947F9"
+            BuildableName = "SiestaTools.framework"
+            BlueprintName = "SiestaTools iOS"
+            ReferencedContainer = "container:Siesta.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DA8C83401FC600A900C947F9"
+            BuildableName = "SiestaTools.framework"
+            BlueprintName = "SiestaTools iOS"
+            ReferencedContainer = "container:Siesta.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Siesta.xcodeproj/xcshareddata/xcschemes/SiestaTools macOS.xcscheme
+++ b/Siesta.xcodeproj/xcshareddata/xcschemes/SiestaTools macOS.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1300"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DA8B5B4F22DEAC93008E47B0"
+               BuildableName = "SiestaTools.framework"
+               BlueprintName = "SiestaTools macOS"
+               ReferencedContainer = "container:Siesta.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DA8B5B4F22DEAC93008E47B0"
+            BuildableName = "SiestaTools.framework"
+            BlueprintName = "SiestaTools macOS"
+            ReferencedContainer = "container:Siesta.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Siesta.xcodeproj/xcshareddata/xcschemes/SiestaTools tvOS.xcscheme
+++ b/Siesta.xcodeproj/xcshareddata/xcschemes/SiestaTools tvOS.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1300"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "DA8B5B5E22DEADDB008E47B0"
+               BuildableName = "SiestaTools.framework"
+               BlueprintName = "SiestaTools tvOS"
+               ReferencedContainer = "container:Siesta.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "DA8B5B5E22DEADDB008E47B0"
+            BuildableName = "SiestaTools.framework"
+            BlueprintName = "SiestaTools tvOS"
+            ReferencedContainer = "container:Siesta.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Source/Siesta/Entity.swift
+++ b/Source/Siesta/Entity.swift
@@ -156,6 +156,12 @@ public struct Entity<ContentType>
     }
 
 
+extension Entity: Codable where ContentType: Codable
+    {
+    // codability synthesized
+    }
+
+
 /**
   Mixin that provides convenience accessors for the content of an optional contained entity.
 

--- a/Source/Siesta/EntityCache.swift
+++ b/Source/Siesta/EntityCache.swift
@@ -79,7 +79,7 @@ public protocol EntityCache
 
       - Warning: This method may be called on a background thread. Make sure your implementation is threadsafe.
     */
-    func readEntity(forKey key: Key) -> Entity<ContentType>?
+    func readEntity(forKey key: Key) throws -> Entity<ContentType>?
 
     /**
       Store the given entity in the cache, associated with the given key.
@@ -96,18 +96,18 @@ public protocol EntityCache
 
       - Warning: The method may be called on a background thread. Make sure your implementation is threadsafe.
     */
-    func writeEntity(_ entity: Entity<ContentType>, forKey key: Key)
+    func writeEntity(_ entity: Entity<ContentType>, forKey key: Key) throws
 
     /**
       Update the timestamp of the entity for the given key. If there is no such cache entry, do nothing.
     */
-    func updateEntityTimestamp(_ timestamp: TimeInterval, forKey key: Key)
+    func updateEntityTimestamp(_ timestamp: TimeInterval, forKey key: Key) throws
 
     /**
       Remove any entities cached for the given key. After a call to `removeEntity(forKey:)`, subsequent calls to
       `readEntity(forKey:)` for the same key **must** return nil until the next call to `writeEntity(_:forKey:)`.
     */
-    func removeEntity(forKey key: Key)
+    func removeEntity(forKey key: Key) throws
 
     /**
       Returns the GCD queue on which this cache implementation will do its work.
@@ -133,11 +133,11 @@ extension EntityCache
       While this default implementation always gives the correct behavior, cache implementations may choose to override
       it for performance reasons.
     */
-    public func updateEntityTimestamp(_ timestamp: TimeInterval, forKey key: Key)
+    public func updateEntityTimestamp(_ timestamp: TimeInterval, forKey key: Key) throws
         {
-        guard var entity = readEntity(forKey: key) else
+        guard var entity = try readEntity(forKey: key) else
             { return }
         entity.timestamp = timestamp
-        writeEntity(entity, forKey: key)
+        try writeEntity(entity, forKey: key)
         }
     }

--- a/Source/Siesta/EntityCache.swift
+++ b/Source/Siesta/EntityCache.swift
@@ -47,6 +47,12 @@ public protocol EntityCache
     associatedtype Key
 
     /**
+      The type of payload this cache knows how to store and retrieve. If the response data configured at a particular
+      point in the cache does not match this content type, Siesta will log a warning and bypass the cache.
+    */
+    associatedtype ContentType
+
+    /**
       Provides the key appropriate to this cache for the given resource.
 
       A cache may opt out of handling the given resource by returning nil.
@@ -70,7 +76,7 @@ public protocol EntityCache
 
       - Warning: This method may be called on a background thread. Make sure your implementation is threadsafe.
     */
-    func readEntity(forKey key: Key) -> Entity<Any>?
+    func readEntity(forKey key: Key) -> Entity<ContentType>?
 
     /**
       Store the given entity in the cache, associated with the given key. The key’s format is arbitrary, and internal
@@ -88,7 +94,7 @@ public protocol EntityCache
 
       - Warning: The method may be called on a background thread. Make sure your implementation is threadsafe.
     */
-    func writeEntity(_ entity: Entity<Any>, forKey key: Key)
+    func writeEntity(_ entity: Entity<ContentType>, forKey key: Key)
 
     /**
       Update the timestamp of the entity for the given key. If there is no such cache entry, do nothing.

--- a/Source/Siesta/Pipeline/PipelineConfiguration.swift
+++ b/Source/Siesta/Pipeline/PipelineConfiguration.swift
@@ -195,7 +195,18 @@ public struct PipelineStage
       - Note: Siesta may ask your cache for content before any load requests run. This means that your observer may
               initially see an empty resources and then get a `newData(Cache)` event — even if you never call `load()`.
     */
-    public mutating func cacheUsing<T: EntityCache>(_ cache: @autoclosure () throws -> T)
+    public mutating func cacheUsing<T: EntityCache>(_ cache: T)
+        {
+        cacheBox = CacheBox(cache: cache)
+        }
+
+    /**
+      Convenience for `cacheUsing(_:)` that takes a failable closure, for situations where caching is optional.
+
+      Configures a persistent cache at this stage if the given closure succeeds. Disables caching at this stage if the
+      closure throws an error.
+    */
+    public mutating func cacheUsing<T: EntityCache>(_ cache: () throws -> T)
         {
         do
             { cacheBox = CacheBox(cache: try cache()) }

--- a/Source/Siesta/Pipeline/PipelineConfiguration.swift
+++ b/Source/Siesta/Pipeline/PipelineConfiguration.swift
@@ -183,7 +183,8 @@ public struct PipelineStage
         }
 
     /**
-      An optional persistent cache for this stage.
+      Configures a persistent cache for responses after they pass this stage. Passing nil removes any previously
+      configured caching.
 
       When processing a response, the cache will receive the resulting entity after this stage’s transformers have run.
 
@@ -194,8 +195,16 @@ public struct PipelineStage
       - Note: Siesta may ask your cache for content before any load requests run. This means that your observer may
               initially see an empty resources and then get a `newData(Cache)` event — even if you never call `load()`.
     */
-    public mutating func cacheUsing<T: EntityCache>(_ cache: T)
-        { cacheBox = CacheBox(cache: cache) }
+    public mutating func cacheUsing<T: EntityCache>(_ cache: @autoclosure () throws -> T)
+        {
+        do
+            { cacheBox = CacheBox(cache: try cache()) }
+        catch
+            {
+            SiestaLog.log(.cache, ["Error while attempting to create persistent cache for", self, "; caching disabled at this stage:", error])
+            doNotCache()
+            }
+        }
 
     /**
       Removes any caching that had been configured at this stage.

--- a/Source/Siesta/Pipeline/PipelineConfiguration.swift
+++ b/Source/Siesta/Pipeline/PipelineConfiguration.swift
@@ -69,7 +69,7 @@ public struct Pipeline
                 .map(\.key)
             let missingStages = Set(nonEmptyStages).subtracting(newValue)
             if !missingStages.isEmpty
-                { SiestaLog.log(.pipeline, ["WARNING: Stages", missingStages, "configured but not present in custom pipeline order, will be ignored:", newValue]) }
+                { SiestaLog.log(.pipeline, ["WARNING: Stages", missingStages, "are configured but not present in custom pipeline order", newValue, "and will be ignored"]) }
             }
         }
 

--- a/Source/Siesta/Pipeline/PipelineProcessing.swift
+++ b/Source/Siesta/Pipeline/PipelineProcessing.swift
@@ -110,7 +110,7 @@ extension Pipeline
 
         init(for resource: Resource, searching stagesAndEntries: [StageAndEntry])
             {
-            requestDescription = "Cache request for \(resource)"
+            requestDescription = "Cache check for \(resource)"
             self.resource = resource
             self.stagesAndEntries = stagesAndEntries
             }
@@ -179,6 +179,9 @@ extension Pipeline
                 }
             return nil
             }
+
+        var logCategory: SiestaLog.Category?
+            { .cache }
         }
     }
 

--- a/Source/Siesta/Pipeline/PipelineProcessing.swift
+++ b/Source/Siesta/Pipeline/PipelineProcessing.swift
@@ -21,7 +21,7 @@ extension Pipeline
             { stage in (stage, stage.cacheBox?.buildEntry(resource)) }
         }
 
-    internal func makeProcessor(_ rawResponse: Response, resource: Resource) -> () -> Response
+    internal func makeProcessor(_ rawResponse: Response, resource: Resource) -> () -> ResponseInfo
         {
         // Generate cache keys on main thread (because this touches Resource)
         let stagesAndEntries = self.stagesAndEntries(for: resource)
@@ -29,37 +29,37 @@ extension Pipeline
         // Return deferred processor to run on background queue
         return
             {
-            let result = Pipeline.processAndCache(rawResponse, using: stagesAndEntries)
+            let result = Pipeline.process(rawResponse, using: stagesAndEntries)
 
-            SiestaLog.log(.pipeline,       ["  └╴Response after pipeline:", result.summary()])
-            SiestaLog.log(.networkDetails, ["    Details:", result.dump("      ")])
+            SiestaLog.log(.pipeline,       ["  └╴Response after pipeline:", result.response.summary()])
+            SiestaLog.log(.networkDetails, ["    Details:", result.response.dump("      ")])
 
             return result
             }
         }
 
     // Runs on a background queue
-    private static func processAndCache<StagesAndEntries: Collection>(
+    private static func process<StagesAndEntries: Collection>(
             _ rawResponse: Response,
             using stagesAndEntries: StagesAndEntries)
-        -> Response
+        -> ResponseInfo
         where StagesAndEntries.Iterator.Element == StageAndEntry
         {
-        stagesAndEntries.reduce(rawResponse)
+        stagesAndEntries.reduce(into: ResponseInfo(response: rawResponse))
             {
-            let input = $0,
-                (stage, cacheEntry) = $1
+            let (stage, cacheEntry) = $1
 
-            let output = stage.process(input)
+            $0.response = stage.process($0.response)
 
-            if case .success(let entity) = output,
+            if case .success(let entity) = $0.response,
                let cacheEntry = cacheEntry
                 {
-                SiestaLog.log(.cache, ["  ├╴Caching entity with", type(of: entity.content), "content for", cacheEntry])
-                cacheEntry.write(entity)
+                $0.cacheActions.append(
+                    {
+                    SiestaLog.log(.cache, ["Caching entity with", type(of: entity.content), "content for", cacheEntry])
+                    cacheEntry.write(entity)
+                    })
                 }
-
-            return output
             }
         }
 
@@ -136,11 +136,11 @@ extension Pipeline
                     {
                     SiestaLog.log(.cache, ["Cache hit for", cacheEntry])
 
-                    let processed = Pipeline.processAndCache(
+                    let processed = Pipeline.process(
                         .success(result),
                         using: stagesAndEntries.suffix(from: index + 1))
 
-                    switch processed
+                    switch processed.response
                         {
                         case .failure:
                             SiestaLog.log(.cache, ["Error processing cached entity; will ignore cached value. Error:", processed])

--- a/Source/Siesta/Pipeline/PipelineProcessing.swift
+++ b/Source/Siesta/Pipeline/PipelineProcessing.swift
@@ -199,7 +199,10 @@ private struct CacheEntry<Cache, Key>: CacheEntryProtocol
     func read() -> Entity<Any>?
         {
         cache.workQueue.sync
-            { self.cache.readEntity(forKey: self.key)?.withContentRetyped() }
+            {
+            catchAndLogErrors(attemptingTo: "read cached entity")
+                { try self.cache.readEntity(forKey: self.key)?.withContentRetyped() }
+            }
         }
 
     func write(_ entity: Entity<Any>)
@@ -211,18 +214,38 @@ private struct CacheEntry<Cache, Key>: CacheEntryProtocol
             }
 
         cache.workQueue.async
-            { self.cache.writeEntity(cacheableEntity, forKey: self.key) }
+            {
+            self.catchAndLogErrors(attemptingTo: "write cached entity")
+                { try self.cache.writeEntity(cacheableEntity, forKey: self.key) }
+            }
         }
 
     func updateTimestamp(_ timestamp: TimeInterval)
         {
         cache.workQueue.async
-            { self.cache.updateEntityTimestamp(timestamp, forKey: self.key) }
+            {
+            self.catchAndLogErrors(attemptingTo: "update entity timestamp")
+                { try self.cache.updateEntityTimestamp(timestamp, forKey: self.key) }
+            }
         }
 
     func remove()
         {
         cache.workQueue.async
-            { self.cache.removeEntity(forKey: self.key) }
+            {
+            self.catchAndLogErrors(attemptingTo: "remove entity from cache")
+                { try self.cache.removeEntity(forKey: self.key) }
+            }
+        }
+
+    private func catchAndLogErrors<T>(attemptingTo actionName: String, action: () throws -> T?) -> T?
+        {
+        do
+            { return try action() }
+        catch
+            {
+            SiestaLog.log(.cache, ["WARNING:", cache, "unable to", actionName, "for", key, ":", error])
+            return nil
+            }
         }
     }

--- a/Source/Siesta/Pipeline/PipelineProcessing.swift
+++ b/Source/Siesta/Pipeline/PipelineProcessing.swift
@@ -55,7 +55,7 @@ extension Pipeline
             if case .success(let entity) = output,
                let cacheEntry = cacheEntry
                 {
-                SiestaLog.log(.cache, ["  ├╴Caching entity with", type(of: entity.content), "content in", cacheEntry])
+                SiestaLog.log(.cache, ["  ├╴Caching entity with", type(of: entity.content), "content for", cacheEntry])
                 cacheEntry.write(entity)
                 }
 
@@ -180,7 +180,7 @@ private protocol CacheEntryProtocol
     func remove()
     }
 
-private struct CacheEntry<Cache, Key>: CacheEntryProtocol
+private struct CacheEntry<Cache, Key>: CacheEntryProtocol, CustomStringConvertible
     where Cache: EntityCache, Cache.Key == Key
     {
     let cache: Cache
@@ -248,4 +248,7 @@ private struct CacheEntry<Cache, Key>: CacheEntryProtocol
             return nil
             }
         }
+
+    var description: String
+        { "\(key) in \(cache)" }
     }

--- a/Source/Siesta/Pipeline/PipelineProcessing.swift
+++ b/Source/Siesta/Pipeline/PipelineProcessing.swift
@@ -55,13 +55,26 @@ extension Pipeline
                let cacheEntry = cacheEntry
                 {
                 $0.cacheActions.append(
-                    {
-                    SiestaLog.log(.cache, ["Caching entity with", type(of: entity.content), "content for", cacheEntry])
-                    cacheEntry.write(entity)
-                    })
+                    cacheAction(writing: entity, into: cacheEntry))
                 }
             }
         }
+
+    // swiftlint:disable implicit_return
+
+    fileprivate static func cacheAction(
+            writing entity: Entity<Any>,
+            into cacheEntry: CacheEntryProtocol)
+        -> () -> Void
+        {
+        return
+            {
+            SiestaLog.log(.cache, ["Caching entity with", type(of: entity.content), "content for", cacheEntry])
+            cacheEntry.write(entity)
+            }
+        }
+
+    // swiftlint:enable implicit_return
 
     internal func checkCache(for resource: Resource) -> Request
         {
@@ -92,11 +105,13 @@ extension Pipeline
     private struct CacheRequestDelegate: RequestDelegate
         {
         let requestDescription: String
+        private weak var resource: Resource?
         private let stagesAndEntries: [StageAndEntry]
 
         init(for resource: Resource, searching stagesAndEntries: [StageAndEntry])
             {
             requestDescription = "Cache request for \(resource)"
+            self.resource = resource
             self.stagesAndEntries = stagesAndEntries
             }
 
@@ -104,19 +119,18 @@ extension Pipeline
             {
             defaultEntityCacheWorkQueue.async
                 {
-                let response: Response
-                if let entity = self.performCacheLookup()
-                    { response = .success(entity) }
-                else
-                    {
-                    response = .failure(RequestError(
-                        userMessage: NSLocalizedString("Cache miss", comment: "userMessage"),
-                        cause: RequestError.Cause.CacheMiss()))
-                    }
+                var result = self.performCacheLookup()
+                    ?? ResponseInfo(
+                        response: .failure(RequestError(
+                            userMessage: NSLocalizedString("Cache miss", comment: "userMessage"),
+                            cause: RequestError.Cause.CacheMiss())))
+
+                if let resource = self.resource
+                    { result.configurationSource = .init(method: .get, resource: resource) }
 
                 DispatchQueue.main.async
                     {
-                    completionHandler.broadcastResponse(ResponseInfo(response: response))
+                    completionHandler.broadcastResponse(result)
                     }
                 }
             }
@@ -128,7 +142,7 @@ extension Pipeline
             { self }
 
         // Runs on a background queue
-        private func performCacheLookup() -> Entity<Any>?
+        private func performCacheLookup() -> ResponseInfo?
             {
             for (index, (_, cacheEntry)) in stagesAndEntries.enumerated().reversed()
                 {
@@ -136,17 +150,25 @@ extension Pipeline
                     {
                     SiestaLog.log(.cache, ["Cache hit for", cacheEntry])
 
-                    let processed = Pipeline.process(
+                    var processed = Pipeline.process(
                         .success(result),
                         using: stagesAndEntries.suffix(from: index + 1))
+
+                    // TODO: explain this
+                    if let cacheEntry = cacheEntry
+                        {
+                        processed.cacheActions.insert(
+                            Pipeline.cacheAction(writing: result, into: cacheEntry),
+                            at: 0)
+                        }
 
                     switch processed.response
                         {
                         case .failure:
                             SiestaLog.log(.cache, ["Error processing cached entity; will ignore cached value. Error:", processed])
 
-                        case .success(let entity):
-                            return entity
+                        case .success:
+                            return processed
                         }
                     }
                 }

--- a/Source/Siesta/Pipeline/PipelineProcessing.swift
+++ b/Source/Siesta/Pipeline/PipelineProcessing.swift
@@ -199,13 +199,19 @@ private struct CacheEntry<Cache, Key>: CacheEntryProtocol
     func read() -> Entity<Any>?
         {
         cache.workQueue.sync
-            { self.cache.readEntity(forKey: self.key) }
+            { self.cache.readEntity(forKey: self.key)?.withContentRetyped() }
         }
 
     func write(_ entity: Entity<Any>)
         {
+        guard let cacheableEntity = entity.withContentRetyped() as Entity<Cache.ContentType>? else
+            {
+            SiestaLog.log(.cache, ["WARNING: Unable to cache entity:", Cache.self, "expects", Cache.ContentType.self, "but content at this stage of the pipeline is", type(of: entity.content)])
+            return
+            }
+
         cache.workQueue.async
-            { self.cache.writeEntity(entity, forKey: self.key) }
+            { self.cache.writeEntity(cacheableEntity, forKey: self.key) }
         }
 
     func updateTimestamp(_ timestamp: TimeInterval)

--- a/Source/Siesta/Pipeline/PipelineProcessing.swift
+++ b/Source/Siesta/Pipeline/PipelineProcessing.swift
@@ -119,13 +119,13 @@ extension Pipeline
             {
             defaultEntityCacheWorkQueue.async
                 {
-                var result = self.performCacheLookup()
+                var result = performCacheLookup()
                     ?? ResponseInfo(
                         response: .failure(RequestError(
                             userMessage: NSLocalizedString("Cache miss", comment: "userMessage"),
                             cause: RequestError.Cause.CacheMiss())))
 
-                if let resource = self.resource
+                if let resource = resource
                     { result.configurationSource = .init(method: .get, resource: resource) }
 
                 DispatchQueue.main.async
@@ -223,7 +223,7 @@ private struct CacheEntry<Cache, Key>: CacheEntryProtocol, CustomStringConvertib
         cache.workQueue.sync
             {
             catchAndLogErrors(attemptingTo: "read cached entity")
-                { try self.cache.readEntity(forKey: self.key)?.withContentRetyped() }
+                { try cache.readEntity(forKey: key)?.withContentRetyped() }
             }
         }
 
@@ -237,8 +237,8 @@ private struct CacheEntry<Cache, Key>: CacheEntryProtocol, CustomStringConvertib
 
         cache.workQueue.async
             {
-            self.catchAndLogErrors(attemptingTo: "write cached entity")
-                { try self.cache.writeEntity(cacheableEntity, forKey: self.key) }
+            catchAndLogErrors(attemptingTo: "write cached entity")
+                { try cache.writeEntity(cacheableEntity, forKey: key) }
             }
         }
 
@@ -246,8 +246,8 @@ private struct CacheEntry<Cache, Key>: CacheEntryProtocol, CustomStringConvertib
         {
         cache.workQueue.async
             {
-            self.catchAndLogErrors(attemptingTo: "update entity timestamp")
-                { try self.cache.updateEntityTimestamp(timestamp, forKey: self.key) }
+            catchAndLogErrors(attemptingTo: "update entity timestamp")
+                { try cache.updateEntityTimestamp(timestamp, forKey: key) }
             }
         }
 
@@ -255,8 +255,8 @@ private struct CacheEntry<Cache, Key>: CacheEntryProtocol, CustomStringConvertib
         {
         cache.workQueue.async
             {
-            self.catchAndLogErrors(attemptingTo: "remove entity from cache")
-                { try self.cache.removeEntity(forKey: self.key) }
+            catchAndLogErrors(attemptingTo: "remove entity from cache")
+                { try cache.removeEntity(forKey: key) }
             }
         }
 

--- a/Source/Siesta/Request/LiveRequest.swift
+++ b/Source/Siesta/Request/LiveRequest.swift
@@ -92,6 +92,11 @@ public protocol RequestDelegate
       A description of the underlying operation suitable for logging and debugging.
     */
     var requestDescription: String { get }
+
+    /**
+      Indicates where information about requests using this delegate should be logged.
+    */
+    var logCategory: SiestaLog.Category? { get }
     }
 
 extension RequestDelegate
@@ -107,6 +112,12 @@ extension RequestDelegate
     */
     public var progressReportingInterval: TimeInterval
         { 0.05 }
+
+    /**
+      Log info to `SiestaLog.Category.network`.
+     */
+    public var logCategory: SiestaLog.Category?
+        { .network }
     }
 
 /**
@@ -164,7 +175,7 @@ private final class LiveRequest: Request, RequestCompletionHandler, CustomDebugS
             return self
             }
 
-        SiestaLog.log(.network, [delegate.requestDescription])
+        logDelegateStateChange([delegate.requestDescription])
 
         underlyingOperationStarted = true
         delegate.startUnderlyingOperation(passingResponseTo: self)
@@ -186,7 +197,7 @@ private final class LiveRequest: Request, RequestCompletionHandler, CustomDebugS
             return
             }
 
-        SiestaLog.log(.network, ["Cancelled", delegate.requestDescription])
+        logDelegateStateChange(["Cancelled", delegate.requestDescription])
 
         delegate.cancelUnderlyingOperation()
 
@@ -273,6 +284,12 @@ private final class LiveRequest: Request, RequestCompletionHandler, CustomDebugS
         }
 
     // MARK: Debug
+
+    func logDelegateStateChange(_ messageParts: @autoclosure () -> [Any?])
+        {
+        if let category = delegate.logCategory
+            { SiestaLog.log(category, messageParts()) }
+        }
 
     final var debugDescription: String
         {

--- a/Source/Siesta/Request/NetworkRequest.swift
+++ b/Source/Siesta/Request/NetworkRequest.swift
@@ -12,8 +12,9 @@ internal final class NetworkRequestDelegate: RequestDelegate
     {
     // Basic metadata
     private let resource: Resource
+    private let method: RequestMethod
     internal var config: Configuration
-        { resource.configuration(for: underlyingRequest) }
+        { resource.configuration(for: method) }
     internal let requestDescription: String
 
     // Networking
@@ -31,6 +32,9 @@ internal final class NetworkRequestDelegate: RequestDelegate
         self.resource = resource
         self.requestBuilder = requestBuilder
         underlyingRequest = requestBuilder()
+
+        method = RequestMethod(rawValue: underlyingRequest.httpMethod?.lowercased() ?? "")
+            ?? .get  // All unrecognized methods default to .get
 
         requestDescription =
             SiestaLog.Category.enabled.contains(.network) || SiestaLog.Category.enabled.contains(.networkDetails)
@@ -156,6 +160,7 @@ internal final class NetworkRequestDelegate: RequestDelegate
                 {
                 processedInfo = processor()
                 processedInfo.isNew = true
+                processedInfo.configurationSource = (self.method, self.resource)
                 }
             else
                 { processedInfo = rawInfo }  // result from a 304 is already transformed, cached, etc.

--- a/Source/Siesta/Request/NetworkRequest.swift
+++ b/Source/Siesta/Request/NetworkRequest.swift
@@ -94,7 +94,7 @@ internal final class NetworkRequestDelegate: RequestDelegate
         {
         DispatchQueue.mainThreadPrecondition()
 
-        SiestaLog.log(.network, ["Response: ", underlyingResponse?.statusCode ?? error, "←", requestDescription])
+        SiestaLog.log(.network, ["Response:", underlyingResponse?.statusCode ?? error, "←", requestDescription])
         SiestaLog.log(.networkDetails, ["Raw response headers:", underlyingResponse?.allHeaderFields])
         SiestaLog.log(.networkDetails, ["Raw response body:", body?.count ?? 0, "bytes"])
 

--- a/Source/Siesta/Request/NetworkRequest.swift
+++ b/Source/Siesta/Request/NetworkRequest.swift
@@ -160,7 +160,7 @@ internal final class NetworkRequestDelegate: RequestDelegate
                 {
                 processedInfo = processor()
                 processedInfo.isNew = true
-                processedInfo.configurationSource = (self.method, self.resource)
+                processedInfo.configurationSource = .init(method: self.method, resource: self.resource)
                 }
             else
                 { processedInfo = rawInfo }  // result from a 304 is already transformed, cached, etc.

--- a/Source/Siesta/Request/Request.swift
+++ b/Source/Siesta/Request/Request.swift
@@ -253,7 +253,7 @@ public struct ResponseInfo
     public var isNew: Bool
 
     /// Used to determine whether the response is suitable for caching when loaded by a particular resource
-    var configurationSource: (method: RequestMethod, resource: Resource)?
+    var configurationSource: ConfigurationSource?
 
     /// Callbacks to cache this response according to the pipeline config originally used to process it
     var cacheActions: [() -> Void] = []
@@ -270,4 +270,10 @@ public struct ResponseInfo
             response: .failure(RequestError(
                 userMessage: NSLocalizedString("Request cancelled", comment: "userMessage"),
                 cause: RequestError.Cause.RequestCancelled(networkError: nil))))
+
+    struct ConfigurationSource: Equatable
+        {
+        var method: RequestMethod
+        weak var resource: Resource?
+        }
     }

--- a/Source/Siesta/Request/Request.swift
+++ b/Source/Siesta/Request/Request.swift
@@ -252,6 +252,9 @@ public struct ResponseInfo
     /// Used to distinguish `ResourceEvent.newData` from `ResourceEvent.notModified`.
     public var isNew: Bool
 
+    /// Callbacks to cache this response according to the pipeline config originally used to process it
+    var cacheActions: [() -> Void] = []
+
     /// Creates new responseInfo, with `isNew` true by default.
     public init(response: Response, isNew: Bool = true)
         {

--- a/Source/Siesta/Request/Request.swift
+++ b/Source/Siesta/Request/Request.swift
@@ -118,7 +118,7 @@ public protocol Request: AnyObject
 
       The property will always be 1 if a request is completed. Note that the converse is not true: a value of 1 does
       not necessarily mean the request is completed; it means only that we estimate the request _should_ be completed
-      by now. Use the `isCompleted` property to test for actual completion.
+      by now. Use the `state` property to test for actual completion.
     */
     var progress: Double { get }
 

--- a/Source/Siesta/Request/Request.swift
+++ b/Source/Siesta/Request/Request.swift
@@ -252,6 +252,9 @@ public struct ResponseInfo
     /// Used to distinguish `ResourceEvent.newData` from `ResourceEvent.notModified`.
     public var isNew: Bool
 
+    /// Used to determine whether the response is suitable for caching when loaded by a particular resource
+    var configurationSource: (method: RequestMethod, resource: Resource)?
+
     /// Callbacks to cache this response according to the pipeline config originally used to process it
     var cacheActions: [() -> Void] = []
 

--- a/Source/Siesta/Request/RequestCallbacks.swift
+++ b/Source/Siesta/Request/RequestCallbacks.swift
@@ -90,7 +90,7 @@ internal struct CallbackGroup<CallbackArguments>
         completedValue = arguments
 
         // We need to let this mutating method finish before calling the callbacks. Some of them inspect
-        // completeValue (via isCompleted), which causes a simultaneous access error at runtime.
+        // completeValue (via request.state), which causes a simultaneous access error at runtime.
         // See https://github.com/apple/swift-evolution/blob/master/proposals/0176-enforce-exclusive-access-to-memory.md
 
         let snapshot = self

--- a/Source/Siesta/Request/RequestChaining.swift
+++ b/Source/Siesta/Request/RequestChaining.swift
@@ -135,4 +135,10 @@ internal struct RequestChainDelgate: RequestDelegate
         {
         RequestChainDelgate(wrapping: wrappedRequest.repeated(), whenCompleted: determineAction)
         }
+
+    /**
+      Chain requests are silent since their underlying requests are logged already.
+    */
+    var logCategory: SiestaLog.Category?
+        { nil }
     }

--- a/Source/Siesta/Resource/Resource.swift
+++ b/Source/Siesta/Resource/Resource.swift
@@ -369,8 +369,8 @@ public final class Resource: NSObject
         if case .inProgress(let cacheRequest) = cacheCheckStatus
             {
             // isLoading needs to be:
-            //  - false at first,
-            //  - true after loadIfNeeded() while the cache check is in progress, but
+            //  - false at first, even if a cache check has already started,
+            //  - true after loadIfNeeded() while the cache check is still in progress, but
             //  - false again before observers receive a cache hit.
             //
             // To make this happen, we need to add the chained cacheThenNetwork below
@@ -390,10 +390,10 @@ public final class Resource: NSObject
                 {
                 _ in // We don’t need the result of the cache request here; resource state is already updated
 
-                if self.isUpToDate                 // If cached data is up to date...
+                if self.isUpToDate                      // If cached data is up to date...
                     {
-                    self.receiveDataNotModified()  // ...tell observers isLoading is false...
-                    return .useThisResponse        // ...and no need to make a network call!
+                    self.notifyObservers(.notModified)  // ...tell observers isLoading is false...
+                    return .useThisResponse             // ...and no need to make a network call!
                     }
                 else
                     {

--- a/Source/Siesta/Resource/Resource.swift
+++ b/Source/Siesta/Resource/Resource.swift
@@ -68,13 +68,6 @@ public final class Resource: NSObject
             { service.configuration(forResource: self, requestMethod: method) }
         }
 
-    internal func configuration(for request: URLRequest) -> Configuration
-        {
-        configuration(for:
-            RequestMethod(rawValue: request.httpMethod?.lowercased() ?? "")
-                ?? .get)  // All unrecognized methods default to .get
-        }
-
     private var cachedConfig: [RequestMethod:Configuration] = [:]
     private var configVersion: UInt64 = 0
 
@@ -476,8 +469,19 @@ public final class Resource: NSObject
 
         req.onCompletion
             {
-            for action in $0.cacheActions
-                { action() }
+            // TODO: explain this
+            if let configurationSource = $0.configurationSource
+                {
+                if configurationSource == (.get, self)
+                    {
+                    for action in $0.cacheActions
+                        { action() }
+                    }
+                else
+                    {
+                    SiestaLog.log(.cache, ["Resource.load(using:) will not cache the results of this request because it is not a GET and/or is for a different resource:", configurationSource.method, configurationSource.resource])
+                    }
+                }
             }
 
         req.onNewData(receiveNewDataFromNetwork)

--- a/Source/Siesta/Resource/Resource.swift
+++ b/Source/Siesta/Resource/Resource.swift
@@ -474,6 +474,12 @@ public final class Resource: NSObject
 
         req.onProgress(notifyObservers(ofProgress:))
 
+        req.onCompletion
+            {
+            for action in $0.cacheActions
+                { action() }
+            }
+
         req.onNewData(receiveNewDataFromNetwork)
         req.onNotModified(receiveDataNotModified)
         req.onFailure(receiveError)

--- a/Source/Siesta/Support/Logging.swift
+++ b/Source/Siesta/Support/Logging.swift
@@ -77,7 +77,7 @@ public enum SiestaLog
                         .forceUnwrapped(because: "Modulus always maps thread IDs to valid unicode scalars")))
                 threadID /= 0x55
                 }
-            threadName += "]"
+            threadName += "] "
             }
         let prefix = "Siesta:\(paddedCategory) │ \(threadName)"
         let indentedMessage = $1.replacingOccurrences(of: "\n", with: "\n" + prefix)

--- a/Source/Siesta/Support/SiestaTools.h
+++ b/Source/Siesta/Support/SiestaTools.h
@@ -1,0 +1,16 @@
+//
+//  SiestaTools.h
+//  Siesta
+//
+//  Created by Paul on 2017/11/22.
+//  Copyright © 2016 Bust Out Solutions. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for SiestaTools.
+FOUNDATION_EXPORT double SiestaToolsVersionNumber;
+
+//! Project version string for SiestaTools.
+FOUNDATION_EXPORT const unsigned char SiestaToolsVersionString[];
+

--- a/Source/SiestaTools/FileCache.swift
+++ b/Source/SiestaTools/FileCache.swift
@@ -23,11 +23,13 @@ private let encoder: PropertyListEncoder =
     return encoder
     }()
 
-public struct FileCache<ContentType>: EntityCache
+public struct FileCache<ContentType>: EntityCache, CustomStringConvertible
     where ContentType: Codable
     {
     private let isolationStrategy: DataIsolationStrategy
     private let cacheDir: File
+
+    public let description: String
 
     public init(poolName: String = "Default", dataIsolation isolationStrategy: DataIsolationStrategy) throws
         {
@@ -38,26 +40,30 @@ public struct FileCache<ContentType>: EntityCache
             .appendingPathComponent(poolName)
         try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
 
-        self.init(inDirectory: cacheDir, dataIsolation: isolationStrategy)
+        self.init(inDirectory: cacheDir, dataIsolation: isolationStrategy, cacheName: "poolName: " + poolName)
         }
 
-    public init(inDirectory cacheDir: URL, dataIsolation isolationStrategy: DataIsolationStrategy)
+    public init(
+            inDirectory cacheDir: URL,
+            dataIsolation isolationStrategy: DataIsolationStrategy,
+            cacheName: String? = nil)
         {
         self.cacheDir = cacheDir
         self.isolationStrategy = isolationStrategy
+        self.description = "\(type(of: self))(\(cacheName ?? cacheDir.path))"
         }
 
     // MARK: - Keys and filenames
 
     public func key(for resource: Resource) -> Key?
-        { Key(resource: resource, isolatedUsing: isolationStrategy) }
+        { Key(resource: resource, isolationStrategy: isolationStrategy) }
 
     public struct Key: CustomStringConvertible
         {
         fileprivate var hash: String
         private var url: URL
 
-        fileprivate init(resource: Resource, isolatedUsing isolationStrategy: DataIsolationStrategy)
+        fileprivate init(resource: Resource, isolationStrategy: DataIsolationStrategy)
             {
             url = resource.url
             hash = isolationStrategy.keyData(for: url)

--- a/Source/SiestaTools/FileCache.swift
+++ b/Source/SiestaTools/FileCache.swift
@@ -69,7 +69,7 @@ public struct FileCache<ContentType>: EntityCache
 
     // MARK: - Reading and writing
 
-    public func readEntity(forKey key: Key) -> Entity<ContentType>?
+    public func readEntity(forKey key: Key) throws -> Entity<ContentType>?
         {
         do  {
             return try
@@ -78,13 +78,11 @@ public struct FileCache<ContentType>: EntityCache
                 .entity
             }
         catch CocoaError.fileReadNoSuchFile
-            { }  // a cache miss is just fine
-        catch
-            { SiestaLog.log(.cache, ["WARNING: FileCache unable to read cached entity for", key, ":", error]) }
+            { }  // a cache miss is just fine; don't log it
         return nil
         }
 
-    public func writeEntity(_ entity: Entity<ContentType>, forKey key: Key)
+    public func writeEntity(_ entity: Entity<ContentType>, forKey key: Key) throws
         {
         #if os(macOS)
             let options: Data.WritingOptions = [.atomic]
@@ -92,21 +90,13 @@ public struct FileCache<ContentType>: EntityCache
             let options: Data.WritingOptions = [.atomic, .completeFileProtection]
         #endif
 
-        do  {
-            try encoder.encode(EncodableEntity(entity))
-                .write(to: file(for: key), options: options)
-            }
-        catch
-            { SiestaLog.log(.cache, ["WARNING: FileCache unable to write entity for", key, ":", error]) }
+        try encoder.encode(EncodableEntity(entity))
+            .write(to: file(for: key), options: options)
         }
 
-    public func removeEntity(forKey key: Key)
+    public func removeEntity(forKey key: Key) throws
         {
-        do  {
-            try FileManager.default.removeItem(at: file(for: key))
-            }
-        catch
-            { SiestaLog.log(.cache, ["WARNING: FileCache unable to clear cache entity for", key, ":", error]) }
+        try FileManager.default.removeItem(at: file(for: key))
         }
     }
 

--- a/Source/SiestaTools/FileCache.swift
+++ b/Source/SiestaTools/FileCache.swift
@@ -9,6 +9,7 @@
 #if !COCOAPODS
     import Siesta
 #endif
+import Foundation
 import CommonCrypto
 
 private typealias File = URL

--- a/Source/SiestaTools/FileCache.swift
+++ b/Source/SiestaTools/FileCache.swift
@@ -115,9 +115,11 @@ extension FileCache
         private init(keyIsolator: Data)
             {
             keyPrefix =
-                fileCacheFormatVersion  // prevents us from parsing old cache entries using some new future format
-                 + keyIsolator          // prevents one user from seeing another’s cached requests
-                 + [0]                  // separator for URL
+                fileCacheFormatVersion         // prevents us from parsing old cache entries using some new future format
+                 + "\(ContentType.self)".utf8  // prevent data collision when caching at multiple pipeline stages
+                 + [0]                         // null-terminate ContentType to prevent bleed into username
+                 + keyIsolator                 // prevents one user from seeing another’s cached requests
+                 + [0]                         // separator for URL
             }
 
         fileprivate func keyData(for url: URL) -> Data

--- a/Source/SiestaTools/FileCache.swift
+++ b/Source/SiestaTools/FileCache.swift
@@ -1,0 +1,157 @@
+//
+//  FileCache.swift
+//  Siesta
+//
+//  Created by Paul on 2017/11/22.
+//  Copyright © 2017 Bust Out Solutions. All rights reserved.
+//
+
+#if !COCOAPODS
+    import Siesta
+#endif
+import CommonCrypto
+
+private typealias File = URL
+
+private let fileCacheFormatVersion: [UInt8] = [0]
+
+public struct FileCache<ContentType>: EntityCache
+    where ContentType: Codable
+    {
+    private let keyPrefix: Data
+    private let cacheDir: File
+
+    private let encoder = PropertyListEncoder()
+    private let decoder = PropertyListDecoder()
+
+    public init<T>(poolName: String = "Default", userIdentity: T?) throws
+        where T: Encodable
+        {
+        encoder.outputFormat = .binary
+
+        self.keyPrefix = try
+            fileCacheFormatVersion           // prevents us from parsing old cache entries using some new future format
+             + encoder.encode(userIdentity)  // prevents one user from seeing another’s cached requests
+             + [0]                           // separator for URL
+
+        cacheDir = try
+            FileManager.default.url(
+                for: .cachesDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+            .appendingPathComponent(Bundle.main.bundleIdentifier ?? "")
+            .appendingPathComponent("Siesta")
+            .appendingPathComponent(poolName)
+        try FileManager.default.createDirectory(at: cacheDir, withIntermediateDirectories: true)
+        }
+
+    // MARK: - Keys and filenames
+
+    public func key(for resource: Resource) -> Key?
+        { Key(resource: resource, prefix: keyPrefix) }
+
+    public struct Key: CustomStringConvertible
+        {
+        fileprivate var url, hash: String
+
+        fileprivate init(resource: Resource, prefix: Data)
+            {
+            url = resource.url.absoluteString
+            hash = Data(prefix + url.utf8)
+                .sha256
+                .urlSafeBase64EncodedString
+            }
+
+        public var description: String
+            { "FileCache.Key(\(url))" }
+        }
+
+    private func file(for key: Key) -> File
+        { cacheDir.appendingPathComponent(key.hash + ".plist") }
+
+    // MARK: - Reading and writing
+
+    public func readEntity(forKey key: Key) -> Entity<ContentType>?
+        {
+        do  {
+            return try
+                decoder.decode(EncodableEntity<ContentType>.self,
+                    from: Data(contentsOf: file(for: key)))
+                .entity
+            }
+        catch CocoaError.fileReadNoSuchFile
+            { }  // a cache miss is just fine
+        catch
+            { SiestaLog.log(.cache, ["WARNING: FileCache unable to read cached entity for", key, ":", error]) }
+        return nil
+        }
+
+    public func writeEntity(_ entity: Entity<ContentType>, forKey key: Key)
+        {
+        #if os(macOS)
+            let options: Data.WritingOptions = [.atomic]
+        #else
+            let options: Data.WritingOptions = [.atomic, .completeFileProtection]
+        #endif
+
+        do  {
+            try encoder.encode(EncodableEntity(entity))
+                .write(to: file(for: key), options: options)
+            }
+        catch
+            { SiestaLog.log(.cache, ["WARNING: FileCache unable to write entity for", key, ":", error]) }
+        }
+
+    public func removeEntity(forKey key: Key)
+        {
+        do  {
+            try FileManager.default.removeItem(at: file(for: key))
+            }
+        catch
+            { SiestaLog.log(.cache, ["WARNING: FileCache unable to clear cache entity for", key, ":", error]) }
+        }
+    }
+
+/// Ideally, Entity itself would be codable when its ContentType is codable. To do this, Swift would need to:
+///
+///   1. allow conditional conformance, and
+///   2. allow extensions to synthesize encode/decode.
+///
+/// This struct is a stopgap until the language can do all that.
+///
+private struct EncodableEntity<ContentType>: Codable
+    where ContentType: Codable
+    {
+    var timestamp: TimeInterval
+    var headers: [String:String]
+    var charset: String?
+    var content: ContentType
+
+    init(_ entity: Entity<ContentType>)
+        {
+        timestamp = entity.timestamp
+        headers = entity.headers
+        charset = entity.charset
+        content = entity.content
+        }
+
+    var entity: Entity<ContentType>
+        { Entity(content: content, charset: charset, headers: headers, timestamp: timestamp) }
+    }
+
+extension Data
+    {
+    var sha256: Data
+        {
+        var hash = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+        _ = withUnsafeBytes
+            { CC_SHA256($0.baseAddress, CC_LONG(count), &hash) }
+        return Data(hash)
+        }
+
+    var urlSafeBase64EncodedString: String
+        {
+        base64EncodedString()
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "=", with: "")
+        }
+    }

--- a/Tests/.swiftlint.yml
+++ b/Tests/.swiftlint.yml
@@ -8,5 +8,5 @@ disabled_rules:
 
 custom_rules:
   focused_spec:
-    name: "Focused spec in effect"
-    regex: '(fit|fdescribe)\s*\('
+    name: "Remember not to commit any focused or disabled specs!"
+    regex: '\b[fx](it|describe)\s*\('

--- a/Tests/Functional/EntityCacheSpec.swift
+++ b/Tests/Functional/EntityCacheSpec.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2018 Bust Out Solutions. All rights reserved.
 //
 
-import Siesta
+@testable import Siesta
 
 import Foundation
 import Quick
@@ -16,9 +16,12 @@ class EntityCacheSpec: ResourceSpecBase
     {
     override func resourceSpec(_ service: @escaping () -> Service, _ resource: @escaping () -> Resource)
         {
-        func configureCache<C: EntityCache>(_ cache: C, at stageKey: PipelineStageKey)
+        func configureCache<C: EntityCache>(
+                _ cache: C,
+                for pattern: ConfigurationPatternConvertible = "**",
+                at stageKey: PipelineStageKey)
             {
-            service().configure
+            service().configure(pattern)
                 { $0.pipeline[stageKey].cacheUsing(cache) }
             }
 
@@ -168,6 +171,15 @@ class EntityCacheSpec: ResourceSpecBase
 
         describe("write")
             {
+            @discardableResult
+            func stubAndAwaitRequestWithoutLoading(for resource: Resource, method: RequestMethod) -> Request
+                {
+                NetworkStub.add(method, { resource })
+                let req = resource.request(method)
+                awaitNewData(req, initialState: .inProgress)
+                return req
+                }
+
             func expectCacheWrite(to cache: TestCache, content: String)
                 {
                 waitForCacheWrite(cache)
@@ -175,7 +187,7 @@ class EntityCacheSpec: ResourceSpecBase
                 expect(cache.entries.values.first?.typedContent()) == content
                 }
 
-            it("caches new data on success")
+            it("caches new data on a successful load()")
                 {
                 let testCache = TestCache("new data")
                 configureCache(testCache, at: .cleanup)
@@ -230,6 +242,40 @@ class EntityCacheSpec: ResourceSpecBase
                     with: Entity<Any>(content: "should not be cached", contentType: "text/string"))
 
                 expect(testCache.entries).toEventually(beEmpty())
+                }
+
+            it("does not cache anything for call to Resource.request() without load()")
+                {
+                configureCache(UnwritableCache(), at: .cleanup)
+                stubAndAwaitRequestWithoutLoading(for: resource(), method: .get)
+                }
+
+            it("caches new data for a GET on the same resource passed to load(using:)")
+                {
+                let testCache = TestCache("new data from load(using:)")
+                configureCache(testCache, at: .cleanup)
+                let req = stubAndAwaitRequestWithoutLoading(for: resource(), method: .get)
+                resource().load(using: req)
+                expectCacheWrite(to: testCache, content: "decparmodcle")
+                }
+
+            it("does not cache anything for a non-GET request, even if passed to load(using:)")
+                {
+                configureCache(UnwritableCache(), at: .cleanup)
+                for method in RequestMethod.allCases
+                    where method != .get
+                        {
+                        let req = stubAndAwaitRequestWithoutLoading(for: resource(), method: method)
+                        resource().load(using: req)
+                        }
+                }
+
+            it("does not cache anything for a GET request for a different resource, even if passed to load(using:)")
+                {
+                let otherResource = service().resource("/otherResource")
+                configureCache(UnwritableCache(), at: .cleanup)
+                let req = stubAndAwaitRequestWithoutLoading(for: otherResource, method: .get)
+                resource().load(using: req)
                 }
             }
 
@@ -376,10 +422,10 @@ private struct UnwritableCache: EntityCache
         { nil }
 
     func writeEntity(_ entity: Entity<Any>, forKey key: URL)
-        { fatalError("cache should never be written to") }
+        { fail("cache should never be written to") }
 
     func removeEntity(forKey key: URL)
-        { fatalError("cache should never be written to") }
+        { fail("cache should never be written to") }
     }
 
 private class ObserverEventRecorder: ResourceObserver

--- a/Tests/Functional/EntityCacheSpec.swift
+++ b/Tests/Functional/EntityCacheSpec.swift
@@ -237,6 +237,17 @@ class EntityCacheSpec: ResourceSpecBase
                     .toEventually(equal(2000))
                 }
 
+            it("preserves the timestamp of cached data")
+                {
+                let testCache = UnwritableCache(cachedValue:
+                    Entity(content: "hi", charset: nil, headers: [:], timestamp: 2001))
+                configureCache(testCache, at: .cleanup)
+
+                setResourceTime(2010)
+                awaitNewData(resource().loadIfNeeded()!)
+                expect(resource().latestData?.timestamp) == 2001
+                }
+
             it("clears cached data on local override")
                 {
                 let testCache = TestCache("local override")
@@ -331,9 +342,10 @@ class EntityCacheSpec: ResourceSpecBase
 
             it("will restore cache state to original state if original cache request is passed to load(using:)")
                 {
-                let testCacheDec = TestCache("restore cache state - dec")
+                let testCacheMod = TestCache("restore cache state - mod")
                 let testCacheCle = TestCache("restore cache state - cle")
-                configureCache(testCacheDec, at: .model)
+                configureCache(testCacheMod, at: .model)
+                configureCache(testCacheMod, at: .model)
                 configureCache(testCacheCle, at: .cleanup)
                 service().configure
                     {
@@ -341,7 +353,7 @@ class EntityCacheSpec: ResourceSpecBase
                     $0.pipeline[.decoding].add(TextResponseTransformer())
                     }
 
-                testCacheDec.entries[TestCacheKey(forTestResourceIn: testCacheDec)] =
+                testCacheMod.entries[TestCacheKey(forTestResourceIn: testCacheMod)] =
                     Entity(content: "🌮", contentType: "text/plain")
                 let originalReq = resource().loadIfNeeded()!
                 awaitNewData(originalReq, initialState: .inProgress)
@@ -349,11 +361,11 @@ class EntityCacheSpec: ResourceSpecBase
 
                 stubText("🧇")
                 awaitNewData(resource().load(), initialState: .inProgress)
-                expectCacheWrite(to: testCacheDec, content: "🧇parmod")
+                expectCacheWrite(to: testCacheMod, content: "🧇parmod")
                 expectCacheWrite(to: testCacheCle, content: "🧇parmodcle")
 
                 resource().load(using: originalReq)
-                expectCacheWrite(to: testCacheDec, content: "🌮")
+                expectCacheWrite(to: testCacheMod, content: "🌮")
                 expectCacheWrite(to: testCacheCle, content: "🌮cle")
                 }
             }
@@ -494,11 +506,16 @@ private class KeylessCache: EntityCache
 
 private struct UnwritableCache: EntityCache
     {
+    let cachedValue: Entity<Any>?
+
+    init(cachedValue: Entity<Any>? = nil)
+        { self.cachedValue = cachedValue }
+
     func key(for resource: Resource) -> URL?
         { resource.url }
 
     func readEntity(forKey key: URL) -> Entity<Any>?
-        { nil }
+        { cachedValue }
 
     func writeEntity(_ entity: Entity<Any>, forKey key: URL)
         { fail("cache should never be written to") }

--- a/Tests/Functional/FileCacheSpec.swift
+++ b/Tests/Functional/FileCacheSpec.swift
@@ -1,0 +1,24 @@
+//
+//  FileCacheSpec.swift
+//  Siesta
+//
+//  Created by Paul on 2020/4/6.
+//  Copyright © 2020 Bust Out Solutions. All rights reserved.
+//
+
+import Siesta
+import SiestaTools
+
+import Foundation
+import Quick
+import Nimble
+
+class FileCacheSpec: ResourceSpecBase
+    {
+    override func resourceSpec(_ service: @escaping () -> Service, _ resource: @escaping () -> Resource)
+        {
+        it("needs testing")
+            {
+            }
+        }
+    }

--- a/Tests/Functional/RequestSpec.swift
+++ b/Tests/Functional/RequestSpec.swift
@@ -670,7 +670,7 @@ class RequestSpec: ResourceSpecBase
                 expectResult("yoyo", for: chainedReq)
                 }
 
-            it("isCompleted is false until a “use” action")
+            it("state is inProgress until callback returns a “use response” action")
                 {
                 let reqStub = stubText("yo").delay()
                 let req = resource().request(.get).chained


### PR DESCRIPTION
This PR adds a file-based cache implementation to Siesta. This will give most projects offline access & fast launch for almost free.

A word on why this is so compelling for Siesta: traditional HTTP caches (such as `URLSession`’s cache) exist to _prevent_ requests for data that is still fresh (enough). This makes them good for reducing network traffic, but bad for offline access: it’s a strict choice between getting the cached data or the fresh network data. Worse yet, the API gets to make that choice for you based on (usually ill-behaved) HTTP headers!

Siesta’s architecture, however, makes it possible for a Resource to simultaneously _have_ data and _be in the midst of requesting_ data. This makes it possible for your app to launch with the last data it last had — no matter how old, you decide whether you want to show it — and show that stored data even as it is requesting fresh data, even if that request fails.

This all happens fairly transparently for Siesta apps. Called `loadIfNeeded` and you’ll get a `newData(cache)` event when the cached data arrives, then a `newData(network)` event if the load request succeeds. All you have to do is build your UI so that loading and network errors don’t completely obscure the UI, and bingo! offline access.

There is still documentation work and cleanup to do here, but **the code on this branch should be ready to use in your project!** I encourage Siesta users to try it and report back. Please give it a whirl! 🙏

To try it out:

```swift
service.configure {
    $0.pipeline[.rawData].cacheUsing {
        try FileCache<Data>(
            poolName: “some locally unique name for your API",
            dataIsolation: .perUser(identifiedBy: someUserSpecificValue))
    }
}
```

…or if you are using public data that can be shared across users of the app:

```swift
            dataIsolation: .sharedByAllUsers
```

This PR also fixes numerous subtle problems with the existing cache infrastructure. It’s long been possible roll your own persistent caching for Siesta, but it always involved a bit of per-project finagling. Improvements here should make custom caches both easier to write and easier to work with — most notably, caches now **only apply to GET requests** and **do not apply to cross-resource requests with `load(using:)`**. These two gotchas were a common source of trouble with custom cache implementations.

Fixes #289. Fixes #291.