### PR TITLE
SwiftPM Quick dependency fix

### DIFF
--- a/Examples/GithubBrowser/Podfile.lock
+++ b/Examples/GithubBrowser/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - Siesta/Core (1.5.0)
-  - Siesta/UI (1.5.0):
+  - Siesta/Core (1.5.1)
+  - Siesta/UI (1.5.1):
     - Siesta/Core
 
 DEPENDENCIES:
@@ -11,7 +11,7 @@ EXTERNAL SOURCES:
     :path: "../.."
 
 SPEC CHECKSUMS:
-  Siesta: 407b99ae05344d2de33d98e9e239551086daee6a
+  Siesta: 0b689eff328778c754c4f9afe33ffd70af5ada3d
 
 PODFILE CHECKSUM: 974001388daa9ecbfa915ea0bc4093a33242099c
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -41,9 +41,9 @@
         "package": "Quick",
         "repositoryURL": "https://github.com/pcantrell/Quick",
         "state": {
-          "branch": "around-each",
-          "revision": "d91676d00600c42f9b55349765b1f1099141bfba",
-          "version": null
+          "branch": null,
+          "revision": "39b75c1cd536acb95f643bde93de45e272ccaf86",
+          "version": "0.0.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@ let package = Package(
         .package(url: "https://github.com/Alamofire/Alamofire", .upToNextMajor(from: "5.0.5")),
 
         // For tests:
-        .package(url: "https://github.com/pcantrell/Quick", .branch("around-each")), 
+        .package(url: "https://github.com/pcantrell/Quick", .exact("0.0.0")), 
         .package(url: "https://github.com/Quick/Nimble", from: "8.0.1"),
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ In Xcode:
 
 * File → Swift Packages → Add Package Dependency…
 * Enter `https://github.com/bustoutsolutions/siesta` in the URL field and click Next.
-* For now, depend on the `master` branch. (A branch-based test-only dependency of Siesta currently prevents a versioned dependency on Siesta from working properly. Until this is fixed, you can’t point SwiftPM at Siesta by version.) Click Next.
+* The defaults for the version settings are good for most projects. Click Next.
 * Check the checkbox next to “Siesta.”
     - Also check “SiestaUI” if you want to use any of the [UI helpers](https://github.com/bustoutsolutions/siesta/tree/master/Source/SiestaUI).
     - Also check “Siesta_Alamofire” if you want to use the Alamofire extension for Siesta.

--- a/Siesta.podspec
+++ b/Siesta.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Siesta"
-  s.version      = "1.5.0"
+  s.version      = "1.5.1"
   s.summary      = "Swift REST client library"
 
   s.description  = <<-DESC
@@ -72,7 +72,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.12"
   s.tvos.deployment_target = "10.0"
 
-  s.source = { :git => "https://github.com/bustoutsolutions/siesta.git", :tag => "1.5.0" }
+  s.source = { :git => "https://github.com/bustoutsolutions/siesta.git", :tag => "1.5.1" }
 
   s.subspec "Core" do |s|
     s.source_files = "Source/Siesta/**/*"


### PR DESCRIPTION
Siesta currently fails when added as a SwiftPM dependency using a version number instead of a branch (see #308), because:

- Siesta uses an unmerged feature branch on a fork of Quick,
- Siesta specifies that branch instead of a version number in its dependency on Quick,
- SwiftPM doesn’t allow a versioned dependency (e.g. “Siesta ≥1.5.0”) to have a branch-based dependency, and
- SwiftPM doesn’t know how to ignore test-only targets of dependencies.

This PR fixes the issue by using a newly created ad hoc version number for the `pcantrell` fork of Quick until https://github.com/Quick/Quick/pull/820 is merged.