### PR TITLE
Make Package.swift use swift-tools-version 5.3

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -11,7 +11,7 @@ exclude:
 
 copyright: '© 2020 [Bust Out Solutions](http://bustoutsolutions.com) under [open source license](https://github.com/bustoutsolutions/siesta/blob/master/LICENSE).'
 
-swift_version: 5.2
+swift_version: 5.3.1
 
 theme: fullwidth
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,27 +6,24 @@ branches:
 
 language: objective-c
 os: osx
-osx_image: xcode11.3
+osx_image: xcode12.2
 env:
   - scheme='Siesta macOS' platform='OS X'
-  - scheme='Siesta iOS'   platform='iOS Simulator'  sim_os='iOS'  sim_os_version='13.3'  sim_device='iPhone 11 Pro'
-  - scheme='Siesta iOS'   platform='iOS Simulator'  sim_os='iOS'  sim_os_version='12.4'  sim_device='iPhone SE'
-  - scheme='Siesta iOS'   platform='iOS Simulator'  sim_os='iOS'  sim_os_version='11.4'   sim_device='iPhone 6'
-
-  ## Travis doesn't include iOS 9 anymore, so we unfortunately can't regression test on a 32-bit device:
-  # - scheme='Siesta iOS'   platform='iOS Simulator' sim_os='iOS'  sim_os_version='9.3'   sim_device='iPhone 4s'
-
-  ## Bundled libraries for tvOS on swift 5.1 are broken; restore when Travis publishes xcode11.4:
-  # - scheme='Siesta tvOS'  platform='tvOS Simulator' sim_os='tvOS' sim_os_version='13.3'  sim_device='Apple TV 4K 1080p'
+  - scheme='Siesta iOS'   platform='iOS Simulator'  sim_os='iOS'  sim_os_version='14.2'   sim_device='iPhone 11 Pro'
+  - scheme='Siesta iOS'   platform='iOS Simulator'  sim_os='iOS'  sim_os_version='13.7'   sim_device='iPhone SE'
+  - scheme='Siesta iOS'   platform='iOS Simulator'  sim_os='iOS'  sim_os_version='12.4'   sim_device='iPhone 8'
+  - scheme='Siesta iOS'   platform='iOS Simulator'  sim_os='iOS'  sim_os_version='10.3.1' sim_device='iPhone 6'
+  - scheme='Siesta tvOS'  platform='tvOS Simulator' sim_os='tvOS' sim_os_version='14.0'   sim_device='Apple TV 4K 1080p'
 
 before_install: |
   set -x
 
   if [[ "$platform" =~ \ Simulator$ ]]; then
+    sim_os_version_minor=$(echo $sim_os_version | ruby -ne '$_ =~ /^(\d+\.\d+)/; puts $1')  # spec below doesn't include patch version number
     sim_simulator_udid=$(
       xcrun simctl create "Siesta testing device" \
           "com.apple.CoreSimulator.SimDeviceType.${sim_device// /-}" \
-          "com.apple.CoreSimulator.SimRuntime.${sim_os}-${sim_os_version//./-}"
+          "com.apple.CoreSimulator.SimRuntime.${sim_os}-${sim_os_version_minor//./-}"
     )
     echo "Prelaunching iOS simulator with UDID $sim_simulator_udid"
     xcrun simctl boot $sim_simulator_udid

--- a/Examples/GithubBrowser/Podfile.lock
+++ b/Examples/GithubBrowser/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
-  - Siesta/Core (1.5.1)
-  - Siesta/UI (1.5.1):
+  - Siesta/Core (1.5.2)
+  - Siesta/UI (1.5.2):
     - Siesta/Core
 
 DEPENDENCIES:
@@ -11,8 +11,8 @@ EXTERNAL SOURCES:
     :path: "../.."
 
 SPEC CHECKSUMS:
-  Siesta: 0b689eff328778c754c4f9afe33ffd70af5ada3d
+  Siesta: d1e1966af43ffca170f658ad6d987228a5b40873
 
 PODFILE CHECKSUM: 974001388daa9ecbfa915ea0bc4093a33242099c
 
-COCOAPODS: 1.9.1
+COCOAPODS: 1.10.0

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(

--- a/README.md
+++ b/README.md
@@ -133,14 +133,14 @@ In Xcode:
     - Also check “SiestaUI” if you want to use any of the [UI helpers](https://github.com/bustoutsolutions/siesta/tree/master/Source/SiestaUI).
     - Also check “Siesta_Alamofire” if you want to use the Alamofire extension for Siesta.
 * Click “Finish.”
-* SwiftPM does not yet support resources supplied by dependencies. This means that if:
+* Siesta does not yet support resources supplied by dependencies. This means that if:
     - you included `SiestaUI` above
     - and you plan to use `ResourceStatusOverlay`
     - and you are using its default initializer instead of providing your own custom UI layout,
 
     …then you’ll need to copy [`ResourceStatusOverlay.xib`](https://github.com/bustoutsolutions/siesta/raw/master/Source/SiestaUI/ResourceStatusOverlay.xib) into your own project.
 
-    SwiftPM has support for this coming, but it hasn’t arrived yet as of Swift 5.2.
+    SwiftPM just recently added support for this, and Siesta will add it in the next release.
 
 Please note that Xcode will show _all_ of Siesta’s optional and test-only dependencies, including Quick, Nimble, and Alamofire. Don’t worry: these won’t actually be bundled into your app (except Alamofire, if you use it).
 

--- a/Siesta.podspec
+++ b/Siesta.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Siesta"
-  s.version      = "1.5.1"
+  s.version      = "1.5.2"
   s.summary      = "Swift REST client library"
 
   s.description  = <<-DESC
@@ -72,7 +72,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = "10.12"
   s.tvos.deployment_target = "10.0"
 
-  s.source = { :git => "https://github.com/bustoutsolutions/siesta.git", :tag => "1.5.1" }
+  s.source = { :git => "https://github.com/bustoutsolutions/siesta.git", :tag => "1.5.2" }
 
   s.subspec "Core" do |s|
     s.source_files = "Source/Siesta/**/*"


### PR DESCRIPTION
This causes SwiftPM to stop making Siesta’s test-only dependency versions interact with downstream projects.

Fixes #313.